### PR TITLE
Add GitHub workflows and changelog

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -1,0 +1,31 @@
+name: Auto Close Duplicates
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  close-duplicate:
+    if: github.event.label.name == 'duplicate'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned'
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'This issue has been closed as a duplicate. Please see the linked issue for updates.'
+            });

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,31 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude Triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          model: claude-sonnet-4-5-20250929
+          prompt: |
+            Analyze this new issue and add appropriate labels.
+            Available labels: bug, enhancement, documentation, question, duplicate
+
+            If it's clearly a bug, add 'bug' label.
+            If it's a feature request, add 'enhancement' label.
+            If it's a question, add 'question' label.
+
+            Also add a brief, helpful comment acknowledging the issue.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          model: claude-sonnet-4-5-20250929
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,0 +1,20 @@
+name: Lock Closed Issues
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Daily at 1 AM
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: 30
+          issue-lock-reason: 'resolved'
+          pr-inactive-days: 30
+          pr-lock-reason: 'resolved'

--- a/.github/workflows/stale-issue-manager.yml
+++ b/.github/workflows/stale-issue-manager.yml
@@ -1,0 +1,21 @@
+name: Stale Issue Manager
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs within 7 days.'
+          stale-issue-label: 'stale'
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-issue-labels: 'pinned,security,bug'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# GAL Changelog
+
+## [1.0.0]
+
+- Initial public release
+- Support for Claude Code, Cursor, Windsurf, GitHub Copilot, Cline, and Aider
+- `gal auth login` - GitHub authentication
+- `gal sync --pull` - Sync approved configurations
+- `gal sync --status` - Check sync status
+- Organization-wide configuration management
+- Multi-platform support (macOS, Linux, Windows)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,47 @@
+# GAL Examples
+
+This directory contains examples and guides for using GAL.
+
+## Quick Start
+
+```bash
+# Install GAL
+npm install -g @scheduler-systems/gal
+
+# Authenticate
+gal auth login
+
+# Sync your organization's approved configuration
+gal sync --pull
+```
+
+## Configuration Examples
+
+### Claude Code
+
+After running `gal sync --pull`, your Claude Code configuration will be updated:
+
+```
+~/.claude/
+├── settings.json      # Approved permissions and settings
+├── commands/          # Organization-approved commands
+└── agents/            # Approved agent definitions
+```
+
+### Cursor
+
+```
+~/.cursor/
+├── rules/             # Organization rules
+└── .cursorrules       # Cursor-specific rules
+```
+
+### Windsurf
+
+```
+~/.windsurfrules       # Windsurf rules
+```
+
+## Organization Setup
+
+For administrators setting up GAL for your organization, see the [Admin Guide](https://docs.gal.run/admin).


### PR DESCRIPTION
Adds workflows similar to anthropics/claude-code:

- **CHANGELOG.md** - Version history
- **claude.yml** - Respond to @claude mentions
- **claude-issue-triage.yml** - Auto-triage new issues
- **stale-issue-manager.yml** - Mark stale issues
- **lock-closed-issues.yml** - Lock resolved issues
- **auto-close-duplicates.yml** - Close duplicate issues
- **examples/README.md** - Usage examples

Requires ANTHROPIC_API_KEY secret for Claude workflows.