### PR TITLE
Update README with MCP server docs and refresh changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,44 @@
 # GAL Changelog
 
-## [1.0.6-test] - 2026-01-31
+All notable changes to GAL will be documented in this file.
 
-- See release notes at https://github.com/Scheduler-Systems/gal/releases/tag/v1.0.6-test
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.0.5-test] - 2026-01-31
+## [Unreleased]
 
-- See release notes at https://github.com/Scheduler-Systems/gal/releases/tag/v1.0.5-test
+### Added
+- `gal discover` command for org-wide config scanning with platform filtering
+- Sync Status dashboard page with real-time sync monitoring
+- MCP Server — hosted at `api.gal.run/mcp` for AI agent integration (no install needed)
+- Background agent dispatch rules — admin-configurable work categories
+- Config governance: proposals, versioning, and tracked repos
+- Team management with live GitHub sync
+- Compliance scanning and SDLC status tracking
 
-## [1.0.0]
+### Changed
+- MCP server is now a hosted HTTP service (no npm install required)
+- Expanded MCP tools to 36 (20 governance + 16 agent coordination)
 
-- Initial public release
-- Support for Claude Code, Cursor, Windsurf, GitHub Copilot, Cline, and Aider
-- `gal auth login` - GitHub authentication
-- `gal sync --pull` - Sync approved configurations
-- `gal sync --status` - Check sync status
+### Security
+- Pre-launch hardening: org restriction middleware for background agent APIs
+- MCP endpoint gated by auth + org access
+
+## [1.0.0] - 2026-02-17
+
+### Added
+- Multi-platform support: Claude Code, Cursor, GitHub Copilot, Windsurf, Gemini, Codex
+- `gal auth login` — GitHub authentication
+- `gal sync --pull` — Sync approved configurations
+- `gal sync --status` — Check sync status
 - Organization-wide configuration management
-- Multi-platform support (macOS, Linux, Windows)
+- Auto-discovery of AI agent configs across repositories
+- Approved config management (set org-wide settings)
+- Background agent sessions with dashboard streaming
+- VS Code extension integration
+- CLI telemetry with opt-out support
+- Dashboard with organization discovery, team management, and config governance
+
+### Security
+- Authentication tokens in httpOnly cookies
+- Rate limiting on auth endpoints
+- Org-level access controls

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 <p align="center">
   <a href="https://app.gal.run">Dashboard</a> •
   <a href="https://www.npmjs.com/package/@scheduler-systems/gal">CLI</a> •
-  <a href="https://marketplace.visualstudio.com/items?itemName=scheduler-systems.gal-vscode">VS Code Extension</a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=scheduler-systems.gal-vscode">VS Code Extension</a> •
+  <a href="#mcp-server">MCP Server</a>
 </p>
 
 <p align="center">
@@ -28,6 +29,8 @@ GAL helps you manage AI coding agent configurations at scale:
 - **Auto-Discovery** - Automatically scan repositories to find existing AI agent configurations
 - **Approved Config** - Set organization-wide approved settings
 - **Config Sync** - Pull approved configs with a single command
+- **MCP Server** - Full API access via Model Context Protocol for AI coding agents
+- **Background Agents** - Dispatch and coordinate background coding agents
 
 ## Supported Platforms
 
@@ -36,7 +39,9 @@ GAL helps you manage AI coding agent configurations at scale:
 | Claude Code | `.claude/` | Supported |
 | Cursor | `.cursor/`, `.cursorrules` | Supported |
 | GitHub Copilot | `.github/copilot/` | Supported |
-| Windsurf | `.windsurf/` | Coming Soon |
+| Windsurf | `.windsurf/` | Supported |
+| Gemini | `.gemini/` | Supported |
+| Codex | `.codex/` | Supported |
 
 ## Quick Start
 
@@ -62,6 +67,56 @@ gal auth login
 gal sync --pull
 ```
 
+## MCP Server
+
+GAL provides a hosted MCP (Model Context Protocol) server that gives AI coding agents full access to the GAL API. No installation required — just add the URL to your agent's MCP configuration.
+
+### Setup
+
+Add the GAL MCP server to your agent's configuration:
+
+**Claude Code** (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "gal": {
+      "type": "streamable-http",
+      "url": "https://api.gal.run/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_GAL_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Other MCP-compatible agents** — use the same URL (`https://api.gal.run/mcp`) with your GAL auth token as a Bearer token.
+
+Get your token by running `gal auth login` via the CLI.
+
+### Available Tools
+
+The MCP server exposes governance and agent coordination tools:
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| Organizations | 4 | List orgs, sync, discover configs |
+| Approved Config | 2 | Get/set org-wide approved config |
+| Config Governance | 8 | Proposals, versions, tracked repos |
+| Team Management | 3 | List members, set roles, sync |
+| Compliance | 3 | Scan compliance, get results, SDLC status |
+| Agent Coordination | 16 | Sessions, dispatch, work items, branch claims |
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `gal auth login` | Authenticate with GitHub |
+| `gal sync --pull` | Pull approved configurations |
+| `gal sync --status` | Check sync status |
+| `gal discover` | Scan org repos for AI agent configs |
+
 ## Documentation
 
 https://gal.run/docs
@@ -70,7 +125,7 @@ https://gal.run/docs
 
 - Documentation: https://gal.run/docs
 - Email: support@scheduler-systems.com
-- Issues: https://github.com/Scheduler-Systems/gal.run/issues
+- Issues: https://github.com/Scheduler-Systems/gal-run/issues
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add MCP Server section to README with setup instructions for `api.gal.run/mcp`
- Expand supported platforms (add Windsurf, Gemini, Codex)
- Add CLI commands table
- Refresh CHANGELOG with recent releases (dispatch rules, discover command, sync status, config governance)