### PR TITLE
Fix sync-release workflow failing on re-runs

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -35,8 +35,18 @@ jobs:
           private-key: ${{ secrets.ARC_PRIVATE_KEY }}
 
       - name: Create release branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          # Clean up stale branch from previous runs
+          git push origin --delete release/v$VERSION 2>/dev/null || true
+          git branch -D release/v$VERSION 2>/dev/null || true
+          # Close any orphaned PRs from previous runs
+          EXISTING_PR=$(gh pr list --state open --head release/v$VERSION --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR" --comment "Superseded by new release run" --delete-branch 2>/dev/null || true
+          fi
           git checkout -b release/v$VERSION
 
       - name: Update version in README


### PR DESCRIPTION
## Summary

- Clean up stale `release/v$VERSION` branches from previous failed runs before creating new ones
- Close orphaned PRs from previous runs
- Fixes non-fast-forward push errors that caused all 5 recent sync-release runs to fail

## Root Cause

When the workflow runs multiple times for the same version (e.g., triggered by multiple releases), the `release/v$VERSION` branch from the first run blocks subsequent runs with a non-fast-forward error.

## Test plan

- [ ] Trigger `sync-release` workflow manually with a test version
- [ ] Verify it succeeds even if a previous branch/PR exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)