### PR TITLE
fix: remove runner-policy check from public repo gate

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - run: echo "Ready to merge"
 
-  runner-policy:
-    uses: scheduler-systems/infra/.github/workflows/runner-policy-check.yml@main
-    permissions:
-      contents: read
+  # runner-policy check is not available for public repos
+  # (scheduler-systems/infra is a private repo)
+  # The policy is enforced on the private repo (gal-run-private) instead.


### PR DESCRIPTION
## Summary
Remove runner-policy check from public repo gate — the reusable workflow reference doesn't work for public repos.