### PR TITLE
Fix CLI install instructions: use npm registry instead of GitHub Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,7 @@ Follow the <a href="https://docs.windsurf.com/windsurf/cascade/mcp#mcp-config-js
 Install the GAL CLI for config sync and policy checking:
 
 ```bash
-npm login --registry https://npm.pkg.github.com
-
-npm install -g @scheduler-systems/gal-run --registry https://npm.pkg.github.com
+npm install -g @scheduler-systems/gal-run
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

- CLI is published to npm (`registry.npmjs.org`), not GitHub Packages
- Removed `npm login --registry https://npm.pkg.github.com` requirement
- Simplified install to just `npm install -g @scheduler-systems/gal-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)