### PR TITLE
Fix CI runner labels to match available ARC scale sets

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   close-duplicate:
     if: github.event.label.name == 'duplicate'
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   gate:
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - run: echo "Ready to merge"
 

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lock:
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - uses: dessant/lock-threads@v5
         with:

--- a/.github/workflows/stale-issue-manager.yml
+++ b/.github/workflows/stale-issue-manager.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: arc-linux
+    runs-on: ci-standard-runc-x64
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Fix CI runner labels to match currently available runners. Old labels caused jobs to queue indefinitely.