### PR TITLE
deps: add Dependabot for GitHub Actions (#32)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+# Dependabot - automated dependency updates
+# Issue #32 | Docs: https://docs.github.com/en/code-security/dependabot
+version: 2
+updates:
+  # GitHub Actions (the only package ecosystem in this docs repo)
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "deps(ci)"
+      include: scope


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to enable weekly Dependabot updates for GitHub Actions in this repo.

This is a docs-only repo (no npm/pub/pip dependencies), so only the `github-actions` ecosystem is configured.

Closes #32 (partial — gal-run)