### PR TITLE
chore: add org-hygiene workflows (enforce-milestone, pr-governance)

### DIFF
--- a/.github/workflows/enforce-milestone.yml
+++ b/.github/workflows/enforce-milestone.yml
@@ -1,0 +1,62 @@
+# Enforce Milestone Assignment
+name: Enforce Milestone
+on:
+  issues:
+    types: [opened, reopened, demilestoned]
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions: {}
+jobs:
+  on-issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Assign default milestone if missing
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (issue.milestone) { console.log(`Already has milestone`); return; }
+            const defaultTitle = 'Backlog Triage';
+            async function findOrCreateMilestone() {
+              const all = await github.paginate(github.rest.issues.listMilestones, { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 });
+              const ex = all.find(m => m.title === defaultTitle);
+              if (ex) return ex;
+              try { const c = await github.rest.issues.createMilestone({ owner: context.repo.owner, repo: context.repo.repo, title: defaultTitle, description: 'Default triage milestone' }); return c.data; }
+              catch (err) { if (err.status === 422) { const r = await github.paginate(github.rest.issues.listMilestones, { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 }); const f = r.find(m => m.title === defaultTitle); if (f) return f; } throw err; }
+            }
+            const ms = await findOrCreateMilestone();
+            await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, milestone: ms.number });
+            console.log(`Assigned "${defaultTitle}" to #${issue.number}`);
+  reconcile:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Backfill open issues missing milestones
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const defaultTitle = 'Backlog Triage';
+            async function findOrCreateMilestone() {
+              const all = await github.paginate(github.rest.issues.listMilestones, { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 });
+              const ex = all.find(m => m.title === defaultTitle);
+              if (ex) return ex;
+              try { const c = await github.rest.issues.createMilestone({ owner: context.repo.owner, repo: context.repo.repo, title: defaultTitle, description: 'Default triage milestone' }); return c.data; }
+              catch (err) { if (err.status === 422) { const r = await github.paginate(github.rest.issues.listMilestones, { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 }); const f = r.find(m => m.title === defaultTitle); if (f) return f; } throw err; }
+            }
+            const issues = await github.paginate(github.rest.issues.listForRepo, { owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100 });
+            const um = issues.filter(i => !i.milestone && !i.pull_request);
+            if (um.length === 0) { console.log('Nothing to backfill.'); return; }
+            const ms = await findOrCreateMilestone();
+            let updated = 0;
+            for (const i of um) { try { await github.rest.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: i.number, milestone: ms.number }); updated++; } catch (e) { console.error(`Failed #${i.number}: ${e.message}`); } }
+            console.log(`Backfill: ${updated}/${um.length}`);
+            await core.summary.addHeading('Backfill',3).addRaw(`Assigned "${defaultTitle}" to **${updated}** issue(s).`).write();

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,35 @@
+# Require Issue Reference in PR Body
+name: PR Governance
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+concurrency:
+  group: ${{ format('{0}-{1}-pr-{2}', github.repository, github.workflow, github.event.pull_request.number) }}
+  cancel-in-progress: true
+permissions: {}
+jobs:
+  require-issue-reference:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Require issue reference in PR body
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const authorLogin = (pr.user?.login || '').toLowerCase();
+            const isAutomation = pr.user?.type === 'Bot' || authorLogin.endsWith('[bot]') || (context.actor||'').toLowerCase().endsWith('[bot]') || authorLogin.includes('dependabot') || authorLogin.includes('renovate');
+            if (isAutomation) { core.notice(`Skipping automation PR`); return; }
+            const pat = new RegExp(['\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|address(?:e[sd])?)\\b\\s*:?\\s+','(?:#\\d+|[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+#\\d+|https?:\\/\\/github\\.com\\/[^\\/\\s]+\\/[^\\/\\s]+\\/issues\\/\\d+)'].join(''),'i');
+            if (pat.test(body)) { console.log(`PR #${pr.number} ok`); return; }
+            const marker = '<!-- pr-issue-reference-guidance -->';
+            const guidance = [marker,'## Issue Link Required','','Add one of:','- `Fixes #123`','- `Closes #123`','- `Addresses #123`','','---','*Enforced by [Scheduler-Systems/infra](https://github.com/Scheduler-Systems/infra).*'].join('\n');
+            let commented = false;
+            try { const cs = await github.paginate(github.rest.issues.listComments,{owner:context.repo.owner,repo:context.repo.repo,issue_number:pr.number,per_page:100}); commented = cs.some(c=>(c.body||'').includes(marker)); } catch(e){}
+            if (!commented) { try { await github.rest.issues.createComment({owner:context.repo.owner,repo:context.repo.repo,issue_number:pr.number,body:guidance}); } catch(e){} }
+            core.setFailed('PR body must include an issue reference (e.g. "Fixes #123").');


### PR DESCRIPTION
## Summary

Add org-wide hygiene workflows:
- **enforce-milestone.yml** — auto-assign a default milestone to issues missing one
- **pr-governance.yml** — require issue reference in PR body