### PR TITLE
Add enforce-assignee workflow

### DIFF
--- a/.github/workflows/enforce-assignee.yml
+++ b/.github/workflows/enforce-assignee.yml
@@ -1,0 +1,86 @@
+# Enforce Issue Assignee
+# Guarantees every open issue has at least one assignee.
+#
+# Two jobs:
+#   1. on-issue  – fires on issue opened/reopened, assigns the opener if unassigned
+#   2. reconcile – manual dispatch only, for one-time backfill of existing issues
+name: Enforce Assignee
+
+on:
+  issues:
+    types: [opened, reopened, unassigned]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  # ── Event-driven: assign opener when issue is opened/reopened ──
+  on-issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Assign opener if unassigned
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (issue.assignees && issue.assignees.length > 0) {
+              core.info(`Issue #${issue.number} already has assignees — skipping.`);
+              return;
+            }
+            const opener = issue.user.login;
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [opener],
+            });
+            core.info(`Assigned @${opener} to issue #${issue.number}.`);
+
+  # ── Manual: backfill all open issues missing an assignee ──
+  reconcile:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+    steps:
+      - name: Backfill assignees on open issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let page = 1;
+            let fixed = 0;
+            while (true) {
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+                page,
+              });
+              if (issues.length === 0) break;
+              for (const issue of issues) {
+                // Skip pull requests (GitHub returns them in issues API)
+                if (issue.pull_request) continue;
+                if (issue.assignees && issue.assignees.length > 0) continue;
+                const opener = issue.user.login;
+                await github.rest.issues.addAssignees({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  assignees: [opener],
+                });
+                core.info(`Assigned @${opener} to issue #${issue.number}.`);
+                fixed++;
+              }
+              page++;
+            }
+            core.info(`Reconcile complete. Fixed ${fixed} issue(s).`);


### PR DESCRIPTION
Adds `.github/workflows/enforce-assignee.yml` — auto-assigns the issue opener on `opened`, `reopened`, and `unassigned` events. Run `workflow_dispatch` after merge for one-time backfill.

Closes #83