### PR TITLE
ci: prevent internal content from leaking into public issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,9 @@ labels: bug
 assignees: ''
 ---
 
+> [!WARNING]
+> This is a **public** repository. Do not include internal repo names, runner labels, secret names, GCS bucket paths, or any other private infrastructure details. If your issue contains internal content, open it in the private repo instead.
+
 ## Description
 A clear description of the bug.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,9 @@ labels: enhancement
 assignees: ''
 ---
 
+> [!WARNING]
+> This is a **public** repository. Do not include internal repo names, runner labels, secret names, GCS bucket paths, or any other private infrastructure details. If your issue contains internal content, open it in the private repo instead.
+
 ## Problem
 What problem does this solve?
 

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -17,9 +17,10 @@ jobs:
 
           if grep -RInE \
             --exclude='gate.yml' \
-            'Scheduler-Systems/infra|gal-run-private|arc-linux|ci-standard-runc|docker-dind-x64|macos-host|bare-high-arm64' \
+            --exclude='issue-public-surface-check.yml' \
+            'Scheduler-Systems/infra|gal-run-private|arc-linux|ci-standard-runc|docker-dind-x64|macos-host|bare-high-arm64|ARC_APP_ID|ARC_PRIVATE_KEY|gs://gal' \
             .github README.md CHANGELOG.md; then
-            echo "::error::Public repo contains internal-only references. Remove private repo links, private runner labels, and internal infrastructure details."
+            echo "::error::Public repo contains internal-only references. Remove private repo links, private runner labels, secret names, and internal infrastructure details."
             exit 1
           fi
 

--- a/.github/workflows/issue-public-surface-check.yml
+++ b/.github/workflows/issue-public-surface-check.yml
@@ -1,0 +1,75 @@
+name: Issue Public Surface Check
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for internal references
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title || '';
+            const body  = context.payload.issue.body  || '';
+            const text  = `${title}\n${body}`;
+
+            // Keep in sync with gate.yml — same patterns, applied to issue text
+            const internalPatterns = [
+              /gal-run-private/i,
+              /Scheduler-Systems\/infra/,
+              /arc-linux/i,
+              /ci-standard-runc/i,
+              /docker-dind-x64/i,
+              /macos-host/i,
+              /bare-high-arm64/i,
+              /ARC_APP_ID/,
+              /ARC_PRIVATE_KEY/,
+              /gs:\/\/gal/i,
+            ];
+
+            const hit = internalPatterns.find(p => p.test(text));
+            if (!hit) {
+              core.info('Public surface clean.');
+              return;
+            }
+
+            const n = context.payload.issue.number;
+            core.warning(`Issue #${n} matched internal pattern — closing.`);
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: n,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: n,
+              body: [
+                '> [!CAUTION]',
+                '> **This issue has been automatically closed.**',
+                '>',
+                '> It contains references to internal infrastructure that must not appear in a public repository.',
+                '> Please transfer or re-open it in the appropriate **private** repository.',
+                '>',
+                '> If you believe this was triggered in error, contact a maintainer.',
+              ].join('\n'),
+            });
+
+            await github.rest.issues.lock({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: n,
+              lock_reason: 'off-topic',
+            });
+
+            core.setFailed(`Issue #${n} contained internal references — closed and locked.`);


### PR DESCRIPTION
## Root Cause

An internal issue was created directly in this public repo with internal infrastructure details — private repo names, secret names, internal CI/CD file paths.

**The gap:** `gate.yml` only scans PR file changes. Issue bodies had zero protection.

## Changes

- **New: `issue-public-surface-check.yml`** — triggers on `issues.opened` and `issues.edited`. Scans title + body against the same internal patterns as `gate.yml`. If matched: auto-closes, posts a warning comment, and locks the issue. Catches leaks within seconds of creation.

- **Updated: `gate.yml`** — expanded patterns to also catch internal credential names and internal storage paths (all present in the previous leak but not previously covered).

- **Updated: issue templates** — added a visible `[!WARNING]` banner to both `bug_report.md` and `feature_request.md` so contributors are reminded before they type.

## Test plan
- [ ] Open a test issue containing internal patterns → should be auto-closed and locked within seconds
- [ ] Open a normal issue → should pass through untouched
- [ ] Open a PR with internal credential names in a file → gate should fail

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)