### PR TITLE
[ci] Fix sync-release: use git rm --cached for Casks/gal.rb removal

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -138,7 +138,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           rm -f Casks/gal.rb
-          git add README.md CHANGELOG.md Formula/gal.rb Casks/gal.rb
+          git rm --cached --ignore-unmatch Casks/gal.rb 2>/dev/null || true
+          git add README.md CHANGELOG.md Formula/gal.rb
           if ! git diff --staged --quiet; then
             BRANCH="release/v${VERSION}"
             git checkout -b "$BRANCH"


### PR DESCRIPTION
## Summary

- `rm -f Casks/gal.rb` removes the file but `git add Casks/gal.rb` then fails with exit 128 because the path doesn't exist on disk
- Fix: use `git rm --cached --ignore-unmatch Casks/gal.rb` to stage the deletion if tracked, then `git add` only existing files

## Root cause

```bash
# BROKEN:
rm -f Casks/gal.rb
git add README.md CHANGELOG.md Formula/gal.rb Casks/gal.rb  # ← fatal: pathspec not matched

# FIXED:
rm -f Casks/gal.rb
git rm --cached --ignore-unmatch Casks/gal.rb 2>/dev/null || true
git add README.md CHANGELOG.md Formula/gal.rb
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)