### PR TITLE
[ci] Fix sync-release commit message for require-ci-intent ruleset

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -143,7 +143,7 @@ jobs:
           if ! git diff --staged --quiet; then
             BRANCH="release/v${VERSION}"
             git checkout -b "$BRANCH"
-            git commit -m "Release v$VERSION"
+            git commit -m "[ci] Release v$VERSION"
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
             git push origin "$BRANCH" --force
             EXISTING_PR=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --base main --state open --json url --jq '.[0].url')


### PR DESCRIPTION
## Summary

The `require-ci-intent` org ruleset applies to ALL branches and requires commit messages to match `\[(skip ci|ci skip|ci)\]`. The auto-commit in `sync-release.yml` used `"Release v$VERSION"` which doesn't satisfy this pattern, causing push to fail with `push declined due to repository rule violations`.

Fix: prefix commit message with `[ci]`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)