### PR TITLE
[ci] feat: add Homebrew Cask and auto-bump on release

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -130,6 +130,64 @@ jobs:
           Path("Formula/gal.rb").write_text(formula)
           PY
 
+      - name: Update Homebrew Cask
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          HOMEBREW_PAYLOAD: ${{ toJson(github.event.client_payload.homebrew) }}
+        run: |
+          if [ -z "$HOMEBREW_PAYLOAD" ] || [ "$HOMEBREW_PAYLOAD" = "null" ]; then
+            echo "No Homebrew payload supplied; skipping Cask update"
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import json, os
+          from pathlib import Path
+
+          payload = json.loads(os.environ["HOMEBREW_PAYLOAD"])
+          assets = payload["assets"]
+          version = os.environ["VERSION"]
+          base_url = f"https://github.com/Scheduler-Systems/gal-run/releases/download/v{version}"
+
+          def tarball_sha(asset_key):
+            asset = assets.get(asset_key) or {}
+            tarball = asset.get("tarball") or {}
+            value = tarball.get("sha256")
+            if not value:
+              raise SystemExit(f"Missing Homebrew tarball sha256 for {asset_key}")
+            return value
+
+          cask = f"""cask "gal" do
+            arch arm: "arm64", intel: "x64"
+
+            version "{version}"
+            sha256 arm:    "{tarball_sha('darwinArm64')}",
+                   x86_64: "{tarball_sha('darwinX64')}"
+
+            url "{base_url}/gal-#{{version}}-darwin-#{{arch}}.tar.gz"
+            name "GAL"
+            desc "CLI for GAL — AI agent configuration governance"
+            homepage "https://gal.run"
+
+            livecheck do
+              url :stable
+              strategy :github_latest
+            end
+
+            binary "gal"
+
+            zap trash: [
+              "~/.gal",
+              "~/.config/gal",
+            ]
+          end
+          """
+
+          Path("Casks").mkdir(exist_ok=True)
+          Path("Casks/gal.rb").write_text(cask)
+          print(f"Updated Casks/gal.rb to v{version}")
+          PY
+
       - name: Commit and open PR
         env:
           GH_TOKEN: ${{ github.token }}
@@ -137,9 +195,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          rm -f Casks/gal.rb
-          git rm --cached --ignore-unmatch Casks/gal.rb 2>/dev/null || true
-          git add README.md CHANGELOG.md Formula/gal.rb
+          git add README.md CHANGELOG.md Formula/gal.rb Casks/gal.rb
           if ! git diff --staged --quiet; then
             BRANCH="release/v${VERSION}"
             git checkout -b "$BRANCH"

--- a/Casks/gal.rb
+++ b/Casks/gal.rb
@@ -1,0 +1,24 @@
+cask "gal" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.0.278"
+  sha256 arm:    "a643f8a642a1f0a57b193577f9e31757274c26097ceb1d8769b1b1da9f9470d2",
+         x86_64: "8baa2897722b7fff03924968f4d990c7238c8a4488e7c73eaf22bd16eda58ffc"
+
+  url "https://github.com/Scheduler-Systems/gal-run/releases/download/v#{version}/gal-#{version}-darwin-#{arch}.tar.gz"
+  name "GAL"
+  desc "CLI for GAL — AI agent configuration governance"
+  homepage "https://gal.run"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  binary "gal"
+
+  zap trash: [
+    "~/.gal",
+    "~/.config/gal",
+  ]
+end


### PR DESCRIPTION
## Summary
- Add `Casks/gal.rb` for installation via `brew install --cask gal`
- Update `sync-release.yml` to auto-bump `Casks/gal.rb` version and SHA256s alongside the Formula on each release
- Remove the `rm -f Casks/gal.rb` lines that were deleting the Cask on every release sync

## Install

```bash
brew tap scheduler-systems/gal-run https://github.com/Scheduler-Systems/gal-run.git
brew install --cask gal
```

## Test plan
- [ ] `brew install --cask scheduler-systems/gal-run/gal` installs successfully on macOS arm64
- [ ] `gal --version` works after cask install
- [ ] `brew uninstall --zap gal` removes `~/.gal` and `~/.config/gal`
- [ ] Next release auto-bumps `Casks/gal.rb` version and SHA256s

Fixes #97