### PR TITLE
Extract public filesystem helpers

### DIFF
--- a/.github/workflows/reference-assets.yml
+++ b/.github/workflows/reference-assets.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run reference resolver tests
         run: |
           set -euo pipefail
-          node --test reference/resolve-config.test.mjs
+          node --test reference/*.test.mjs

--- a/docs/workspace-model.md
+++ b/docs/workspace-model.md
@@ -122,6 +122,13 @@ The first public schema drafts live here:
 - [examples/project-config.yaml](../examples/project-config.yaml)
 - [docs/merge-rules.md](merge-rules.md)
 - [reference/resolve-config.mjs](../reference/resolve-config.mjs)
+- [reference/filesystem-helpers.mjs](../reference/filesystem-helpers.mjs)
+
+The current public helper layer now also includes:
+
+- workspace and project path helpers for `~/.gal/workspaces/<workspace>/` and `<repo>/.gal/`
+- current-workspace state helpers for `~/.gal/state/current-workspace.json`
+- project-root discovery that falls back to `.claude/` and `.gal/` when `.git` is absent
 
 ## PR Policy For Public Work
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -149,6 +149,10 @@ For reference merge behavior between workspace scope and repo overrides, see:
 - [../docs/merge-rules.md](../docs/merge-rules.md)
 - [../reference/resolve-config.mjs](../reference/resolve-config.mjs)
 
+For reference filesystem helpers around workspace scope, project scope, and active workspace selection, see:
+
+- [../reference/filesystem-helpers.mjs](../reference/filesystem-helpers.mjs)
+
 ## Organization Setup
 
 For administrators setting up GAL for your organization, see the [Admin Guide](https://docs.gal.run/admin).

--- a/reference/filesystem-helpers.mjs
+++ b/reference/filesystem-helpers.mjs
@@ -1,0 +1,176 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, parse, resolve } from 'node:path';
+
+function validatePathString(value, label) {
+  if (typeof value !== 'string') {
+    throw new TypeError(`${label} must be a string`);
+  }
+
+  if (!value.trim()) {
+    throw new Error(`${label} cannot be empty`);
+  }
+
+  if (value.includes('\0')) {
+    throw new Error(`${label} cannot contain a null byte`);
+  }
+
+  return value;
+}
+
+function validatePathSegment(name, label) {
+  const value = validatePathString(name, label).trim();
+
+  if (
+    value === '.' ||
+    value === '..' ||
+    value.includes('/') ||
+    value.includes('\\')
+  ) {
+    throw new Error(`${label} must be a single path segment`);
+  }
+
+  return value;
+}
+
+function firstDefinedValue(values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+export function getGalRoot({ homeDir = homedir() } = {}) {
+  return join(resolve(validatePathString(homeDir, 'Home directory')), '.gal');
+}
+
+export function getGalStateDir(options = {}) {
+  return join(getGalRoot(options), 'state');
+}
+
+export function getCurrentWorkspacePath(options = {}) {
+  return join(getGalStateDir(options), 'current-workspace.json');
+}
+
+export function getWorkspacesDir(options = {}) {
+  return join(getGalRoot(options), 'workspaces');
+}
+
+export function sanitizeWorkspaceName(name) {
+  return validatePathSegment(name, 'Workspace name');
+}
+
+export function getWorkspaceDir(workspaceName, options = {}) {
+  return join(getWorkspacesDir(options), sanitizeWorkspaceName(workspaceName));
+}
+
+export function getWorkspaceConfigPath(workspaceName, options = {}) {
+  return join(getWorkspaceDir(workspaceName, options), 'config.yaml');
+}
+
+export function getWorkspaceSyncStatePath(workspaceName, options = {}) {
+  return join(getWorkspaceDir(workspaceName, options), 'sync-state.json');
+}
+
+export function readCurrentWorkspaceSelection(options = {}) {
+  const statePath = getCurrentWorkspacePath(options);
+  if (!existsSync(statePath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, 'utf-8'));
+    return typeof parsed.workspace === 'string' && parsed.workspace.trim()
+      ? sanitizeWorkspaceName(parsed.workspace)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCurrentWorkspaceSelection(workspaceName, options = {}) {
+  const stateDir = getGalStateDir(options);
+  mkdirSync(stateDir, { recursive: true });
+  const payload = {
+    workspace: sanitizeWorkspaceName(workspaceName),
+  };
+  writeFileSync(
+    getCurrentWorkspacePath(options),
+    `${JSON.stringify(payload, null, 2)}\n`,
+    'utf-8'
+  );
+}
+
+export function resolveActiveWorkspace({
+  explicitWorkspace,
+  projectWorkspaceRef,
+  gitOwner,
+  currentWorkspace,
+  fallbackWorkspace = 'personal',
+} = {}) {
+  const selected = firstDefinedValue([
+    explicitWorkspace,
+    projectWorkspaceRef,
+    gitOwner,
+    currentWorkspace,
+    fallbackWorkspace,
+  ]);
+
+  return sanitizeWorkspaceName(selected || 'personal');
+}
+
+export function getProjectGalDir(projectRoot) {
+  return join(resolve(validatePathString(projectRoot, 'Project root')), '.gal');
+}
+
+export function getProjectConfigPath(projectRoot) {
+  return join(getProjectGalDir(projectRoot), 'config.yaml');
+}
+
+export function getProjectSyncStatePath(projectRoot) {
+  return join(getProjectGalDir(projectRoot), 'sync-state.json');
+}
+
+export function findProjectRoot(
+  startPath = process.cwd(),
+  {
+    additionalMarkers = ['.claude', '.gal'],
+  } = {}
+) {
+  const resolvedStartPath = resolve(validatePathString(startPath, 'Start path'));
+  const root = parse(resolvedStartPath).root;
+
+  let currentPath = resolvedStartPath;
+  while (true) {
+    if (existsSync(join(currentPath, '.git'))) {
+      return currentPath;
+    }
+
+    if (currentPath === root) {
+      break;
+    }
+
+    currentPath = dirname(currentPath);
+  }
+
+  const markers = additionalMarkers.map((marker) =>
+    validatePathSegment(marker, 'Project marker')
+  );
+
+  currentPath = resolvedStartPath;
+  while (true) {
+    if (markers.some((marker) => existsSync(join(currentPath, marker)))) {
+      return currentPath;
+    }
+
+    if (currentPath === root) {
+      break;
+    }
+
+    currentPath = dirname(currentPath);
+  }
+
+  return resolvedStartPath;
+}

--- a/reference/filesystem-helpers.test.mjs
+++ b/reference/filesystem-helpers.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  findProjectRoot,
+  getCurrentWorkspacePath,
+  getProjectConfigPath,
+  getWorkspaceConfigPath,
+  readCurrentWorkspaceSelection,
+  resolveActiveWorkspace,
+  writeCurrentWorkspaceSelection,
+} from './filesystem-helpers.mjs';
+
+test('workspace helper paths use ~/.gal/workspaces/<workspace>', () => {
+  const homeDir = '/tmp/gal-home';
+  assert.equal(
+    getWorkspaceConfigPath('scheduler-systems', { homeDir }),
+    '/tmp/gal-home/.gal/workspaces/scheduler-systems/config.yaml'
+  );
+  assert.equal(
+    getCurrentWorkspacePath({ homeDir }),
+    '/tmp/gal-home/.gal/state/current-workspace.json'
+  );
+});
+
+test('current workspace selection round-trips through ~/.gal/state/current-workspace.json', () => {
+  const homeDir = mkdtempSync(join(tmpdir(), 'gal-home-'));
+
+  writeCurrentWorkspaceSelection('scheduler-systems', { homeDir });
+
+  assert.equal(
+    readCurrentWorkspaceSelection({ homeDir }),
+    'scheduler-systems'
+  );
+
+  const statePath = getCurrentWorkspacePath({ homeDir });
+  const raw = JSON.parse(readFileSync(statePath, 'utf-8'));
+  assert.deepEqual(raw, { workspace: 'scheduler-systems' });
+});
+
+test('resolveActiveWorkspace honors explicit, project, git, current, then fallback order', () => {
+  assert.equal(
+    resolveActiveWorkspace({
+      explicitWorkspace: 'explicit',
+      projectWorkspaceRef: 'project',
+      gitOwner: 'owner',
+      currentWorkspace: 'current',
+      fallbackWorkspace: 'personal',
+    }),
+    'explicit'
+  );
+
+  assert.equal(
+    resolveActiveWorkspace({
+      projectWorkspaceRef: 'project',
+      gitOwner: 'owner',
+      currentWorkspace: 'current',
+      fallbackWorkspace: 'personal',
+    }),
+    'project'
+  );
+
+  assert.equal(
+    resolveActiveWorkspace({
+      currentWorkspace: 'current',
+    }),
+    'current'
+  );
+});
+
+test('findProjectRoot prefers .git markers when scanning upward', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gal-project-'));
+  const nested = join(projectRoot, 'src', 'utils');
+
+  mkdirSync(join(projectRoot, '.git'));
+  mkdirSync(nested, { recursive: true });
+
+  assert.equal(findProjectRoot(nested), projectRoot);
+  assert.equal(
+    getProjectConfigPath(projectRoot),
+    join(projectRoot, '.gal', 'config.yaml')
+  );
+});
+
+test('findProjectRoot falls back to local markers for non-git projects', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gal-local-project-'));
+  const nested = join(projectRoot, 'docs', 'notes');
+
+  mkdirSync(join(projectRoot, '.claude'));
+  mkdirSync(nested, { recursive: true });
+
+  assert.equal(findProjectRoot(nested), projectRoot);
+});


### PR DESCRIPTION
Addresses #116

## Summary
- publish dependency-free workspace and project filesystem helpers in the public repo
- add active-workspace state helpers and non-git project-root discovery tests
- expand reference-assets CI to run the full reference test suite

## Why
The workspace model and merge rules are already public. The next extractable slice is the local filesystem layer that a public CLI can reuse before any auth or API integration exists.

## Scope
Reference code, tests, and docs only. This is a stacked PR on top of #114 so review stays focused on the new helper layer.
