### PR TITLE
Extract public config document I/O

### DIFF
--- a/docs/workspace-model.md
+++ b/docs/workspace-model.md
@@ -123,12 +123,14 @@ The first public schema drafts live here:
 - [docs/merge-rules.md](merge-rules.md)
 - [reference/resolve-config.mjs](../reference/resolve-config.mjs)
 - [reference/filesystem-helpers.mjs](../reference/filesystem-helpers.mjs)
+- [reference/config-documents.mjs](../reference/config-documents.mjs)
 
 The current public helper layer now also includes:
 
 - workspace and project path helpers for `~/.gal/workspaces/<workspace>/` and `<repo>/.gal/`
 - current-workspace state helpers for `~/.gal/state/current-workspace.json`
 - project-root discovery that falls back to `.claude/` and `.gal/` when `.git` is absent
+- raw workspace and project document I/O for YAML config files and JSON sync-state sidecars
 
 ## PR Policy For Public Work
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -153,6 +153,10 @@ For reference filesystem helpers around workspace scope, project scope, and acti
 
 - [../reference/filesystem-helpers.mjs](../reference/filesystem-helpers.mjs)
 
+For reference document I/O around workspace/project config files and sync-state sidecars, see:
+
+- [../reference/config-documents.mjs](../reference/config-documents.mjs)
+
 ## Organization Setup
 
 For administrators setting up GAL for your organization, see the [Admin Guide](https://docs.gal.run/admin).

--- a/reference/config-documents.mjs
+++ b/reference/config-documents.mjs
@@ -1,0 +1,101 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import {
+  getProjectConfigPath,
+  getProjectSyncStatePath,
+  getWorkspaceConfigPath,
+  getWorkspaceSyncStatePath,
+} from './filesystem-helpers.mjs';
+
+function validateTextContent(content, label) {
+  if (typeof content !== 'string') {
+    throw new TypeError(`${label} must be a string`);
+  }
+
+  if (content.includes('\0')) {
+    throw new Error(`${label} cannot contain a null byte`);
+  }
+
+  return content;
+}
+
+function ensureParentDir(filePath) {
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+
+function readTextDocument(filePath) {
+  if (!existsSync(filePath)) {
+    return {
+      path: filePath,
+      exists: false,
+      content: null,
+    };
+  }
+
+  return {
+    path: filePath,
+    exists: true,
+    content: readFileSync(filePath, 'utf-8'),
+  };
+}
+
+function writeTextDocument(filePath, content) {
+  ensureParentDir(filePath);
+  writeFileSync(filePath, validateTextContent(content, 'Document content'), 'utf-8');
+  return readTextDocument(filePath);
+}
+
+function readJsonDocument(filePath) {
+  if (!existsSync(filePath)) {
+    return {
+      path: filePath,
+      exists: false,
+      value: null,
+    };
+  }
+
+  return {
+    path: filePath,
+    exists: true,
+    value: JSON.parse(readFileSync(filePath, 'utf-8')),
+  };
+}
+
+function writeJsonDocument(filePath, value) {
+  ensureParentDir(filePath);
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  return readJsonDocument(filePath);
+}
+
+export function readWorkspaceConfigDocument(workspaceName, options = {}) {
+  return readTextDocument(getWorkspaceConfigPath(workspaceName, options));
+}
+
+export function writeWorkspaceConfigDocument(workspaceName, content, options = {}) {
+  return writeTextDocument(getWorkspaceConfigPath(workspaceName, options), content);
+}
+
+export function readProjectConfigDocument(projectRoot) {
+  return readTextDocument(getProjectConfigPath(projectRoot));
+}
+
+export function writeProjectConfigDocument(projectRoot, content) {
+  return writeTextDocument(getProjectConfigPath(projectRoot), content);
+}
+
+export function readWorkspaceSyncState(workspaceName, options = {}) {
+  return readJsonDocument(getWorkspaceSyncStatePath(workspaceName, options));
+}
+
+export function writeWorkspaceSyncState(workspaceName, value, options = {}) {
+  return writeJsonDocument(getWorkspaceSyncStatePath(workspaceName, options), value);
+}
+
+export function readProjectSyncState(projectRoot) {
+  return readJsonDocument(getProjectSyncStatePath(projectRoot));
+}
+
+export function writeProjectSyncState(projectRoot, value) {
+  return writeJsonDocument(getProjectSyncStatePath(projectRoot), value);
+}

--- a/reference/config-documents.test.mjs
+++ b/reference/config-documents.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  readProjectConfigDocument,
+  readProjectSyncState,
+  readWorkspaceConfigDocument,
+  readWorkspaceSyncState,
+  writeProjectConfigDocument,
+  writeProjectSyncState,
+  writeWorkspaceConfigDocument,
+  writeWorkspaceSyncState,
+} from './config-documents.mjs';
+
+test('workspace config documents round-trip as raw YAML text', () => {
+  const homeDir = mkdtempSync(join(tmpdir(), 'gal-home-'));
+  const content = [
+    'apiVersion: gal/v1',
+    'kind: WorkspaceConfig',
+    'metadata:',
+    '  id: personal',
+    '',
+  ].join('\n');
+
+  const written = writeWorkspaceConfigDocument('personal', content, { homeDir });
+  assert.equal(written.exists, true);
+  assert.equal(written.content, content);
+
+  const readBack = readWorkspaceConfigDocument('personal', { homeDir });
+  assert.deepEqual(readBack, written);
+});
+
+test('project config documents are stored under <repo>/.gal/config.yaml', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gal-project-'));
+  const content = [
+    'apiVersion: gal/v1',
+    'kind: ProjectConfig',
+    'metadata:',
+    '  workspaceRef: scheduler-systems',
+    '',
+  ].join('\n');
+
+  const written = writeProjectConfigDocument(projectRoot, content);
+  assert.equal(written.exists, true);
+  assert.equal(written.content, content);
+  assert.match(written.path, /\/\.gal\/config\.yaml$/);
+
+  const readBack = readProjectConfigDocument(projectRoot);
+  assert.deepEqual(readBack, written);
+});
+
+test('workspace sync state round-trips as JSON sidecar data', () => {
+  const homeDir = mkdtempSync(join(tmpdir(), 'gal-home-'));
+  const state = {
+    updatedAt: '2026-03-16T10:00:00Z',
+    source: 'local',
+  };
+
+  const written = writeWorkspaceSyncState('personal', state, { homeDir });
+  assert.equal(written.exists, true);
+  assert.deepEqual(written.value, state);
+
+  const readBack = readWorkspaceSyncState('personal', { homeDir });
+  assert.deepEqual(readBack, written);
+});
+
+test('project sync state round-trips as JSON sidecar data', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gal-project-'));
+  const state = {
+    updatedAt: '2026-03-16T10:05:00Z',
+    hash: 'abc123',
+  };
+
+  const written = writeProjectSyncState(projectRoot, state);
+  assert.equal(written.exists, true);
+  assert.deepEqual(written.value, state);
+
+  const readBack = readProjectSyncState(projectRoot);
+  assert.deepEqual(readBack, written);
+});
+
+test('missing config documents return a stable null payload', () => {
+  const homeDir = mkdtempSync(join(tmpdir(), 'gal-home-'));
+  const projectRoot = mkdtempSync(join(tmpdir(), 'gal-project-'));
+
+  assert.deepEqual(readWorkspaceConfigDocument('personal', { homeDir }), {
+    path: join(homeDir, '.gal', 'workspaces', 'personal', 'config.yaml'),
+    exists: false,
+    content: null,
+  });
+
+  assert.deepEqual(readProjectSyncState(projectRoot), {
+    path: join(projectRoot, '.gal', 'sync-state.json'),
+    exists: false,
+    value: null,
+  });
+});


### PR DESCRIPTION
Addresses #118

## Summary
- publish dependency-free workspace/project config document helpers in the public repo
- publish JSON sync-state helpers for workspace and project sidecars
- document the new helper layer in the workspace-model and examples docs

## Why
The filesystem helper layer in #117 resolves where config should live. The next public extraction step is the raw document I/O layer that can read and write those files before YAML parsing is introduced.

## Scope
Reference code, tests, and docs only. This is a stacked PR on top of #117.
