### PR TITLE
[ci] docs: reduce install section to one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,26 +169,6 @@ Install:
 curl -fsSL https://gal.run/install.sh | bash
 ```
 
-<details>
-<summary>Other install methods</summary>
-
-```bash
-# Windows PowerShell
-iwr -useb https://gal.run/install.ps1 | iex
-
-# Homebrew
-brew tap scheduler-systems/gal-run https://github.com/Scheduler-Systems/gal-run.git
-brew install gal
-
-# npm
-npm install -g @scheduler-systems/gal-run
-
-# pnpm
-pnpm add -g @scheduler-systems/gal-run
-```
-
-</details>
-
 Local mode:
 
 ```bash


### PR DESCRIPTION
Closes #123

## Summary
- keep the top-level install section to a single command only
- remove alternative install methods from the top CLI block
- keep the install surface maximally compact

## Testing
- `git diff --check`