### PR TITLE
[ci] docs: guard supported agents matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ See [docs/workspace-model.md](docs/workspace-model.md) for the target scope mode
 
 ## Supported Agents
 
+<!-- SUPPORTED_AGENTS_START -->
 This table is for local CLI support. MCP client compatibility is broader and is documented separately in the MCP section above.
 
 | Agent | Config Files | Local Scan | Local Sync | Memory |
@@ -237,6 +238,7 @@ This table is for local CLI support. MCP client compatibility is broader and is 
 | Windsurf | `.windsurfrules`, `.codeium/windsurf/memories/` | ✓ | ✓ | Native |
 | Antigravity | `.gemini/antigravity/` | ✓ | ✓ | Native |
 | Amp | `AGENTS.md` | ✓ | ✓ | Via GAL |
+<!-- SUPPORTED_AGENTS_END -->
 
 ## Documentation
 

--- a/reference/platform-support.mjs
+++ b/reference/platform-support.mjs
@@ -1,0 +1,75 @@
+export const supportedAgents = [
+  {
+    agent: "Claude Code",
+    configFiles: "`.claude/`, `CLAUDE.md`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Native",
+  },
+  {
+    agent: "Cursor",
+    configFiles: "`.cursor/rules/`, `.cursorrules`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Via GAL",
+  },
+  {
+    agent: "GitHub Copilot",
+    configFiles: "`.github/copilot-instructions.md`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Via GAL",
+  },
+  {
+    agent: "Gemini CLI",
+    configFiles: "`.gemini/`, `GEMINI.md`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Via GAL",
+  },
+  {
+    agent: "Codex (OpenAI)",
+    configFiles: "`AGENTS.md`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Via GAL",
+  },
+  {
+    agent: "Windsurf",
+    configFiles: "`.windsurfrules`, `.codeium/windsurf/memories/`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Native",
+  },
+  {
+    agent: "Antigravity",
+    configFiles: "`.gemini/antigravity/`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Native",
+  },
+  {
+    agent: "Amp",
+    configFiles: "`AGENTS.md`",
+    localScan: "✓",
+    localSync: "✓",
+    memory: "Via GAL",
+  },
+];
+
+export function renderSupportedAgentsSection() {
+  const lines = [
+    "This table is for local CLI support. MCP client compatibility is broader and is documented separately in the MCP section above.",
+    "",
+    "| Agent | Config Files | Local Scan | Local Sync | Memory |",
+    "|-------|-------------|-----------|-----------|--------|",
+  ];
+
+  for (const row of supportedAgents) {
+    lines.push(
+      `| ${row.agent} | ${row.configFiles} | ${row.localScan} | ${row.localSync} | ${row.memory} |`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/reference/platform-support.test.mjs
+++ b/reference/platform-support.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import test from "node:test";
+
+import { renderSupportedAgentsSection } from "./platform-support.mjs";
+
+function extractMarkedSection(readme, startMarker, endMarker) {
+  const start = readme.indexOf(startMarker);
+  const end = readme.indexOf(endMarker);
+
+  assert.notEqual(start, -1, `Missing start marker: ${startMarker}`);
+  assert.notEqual(end, -1, `Missing end marker: ${endMarker}`);
+  assert.ok(end > start, `End marker must appear after start marker: ${endMarker}`);
+
+  return readme.slice(start + startMarker.length, end).trim();
+}
+
+test("README supported agents section matches the generated support matrix", () => {
+  const referenceDir = fileURLToPath(new URL(".", import.meta.url));
+  const readme = readFileSync(join(referenceDir, "..", "README.md"), "utf8");
+  const actual = extractMarkedSection(
+    readme,
+    "<!-- SUPPORTED_AGENTS_START -->",
+    "<!-- SUPPORTED_AGENTS_END -->",
+  );
+
+  assert.equal(actual, renderSupportedAgentsSection());
+});


### PR DESCRIPTION
Closes #126

## Summary
- add a generated support matrix source for the README supported agents section
- add a reference test so the README section cannot drift silently
- keep the local CLI support matrix explicit and stable

## Testing
- `node --test reference/*.test.mjs`
- `git diff --check`