### PR TITLE
Align public local model with ~/.gal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Local mode:
 # Discover your existing AI agent configs
 gal scan
 
-# Standardize them into .gal/config.yaml
+# Standardize them into ~/.gal/config.yaml
 gal approve --local
 
 # Distribute the canonical GAL config to your agents
@@ -202,21 +202,21 @@ Follow the <a href="https://docs.windsurf.com/windsurf/cascade/mcp#mcp-config-js
 
 </details>
 
-## Roadmap
+## Local Model
 
-The next public CLI milestone is a local-first workspace model:
+The current local CLI model is:
 
-- Workspace-scoped GAL config under `~/.gal/workspaces/<workspace>/`
-- Repo-scoped overrides under `<repo>/.gal/`
-- Explicit promotion from local workspace state into GAL Cloud or org workflows
-- Incremental publication of public CLI source into this repository
+- Workspace-scoped GAL config under `~/.gal/config.yaml`
+- Repo-scoped overrides under `<repo>/.gal/config.yaml`
+- Project overrides take precedence over workspace defaults
+- Incremental publication of more local CLI source into this repository
 
-See [docs/workspace-model.md](docs/workspace-model.md) for the target scope model and rollout plan.
+See [docs/workspace-model.md](docs/workspace-model.md) for the current scope model and public extraction plan.
 
 ## Features
 
 - **Local Scan**: Discover AI agent configs on your machine without auth or cloud setup
-- **Local Standardize**: Merge discovered configs into a canonical `.gal/config.yaml`
+- **Local Standardize**: Merge discovered configs into a canonical `~/.gal/config.yaml`
 - **Local Sync**: Distribute the canonical GAL config across Claude, Cursor, Copilot, Gemini, Codex, Windsurf, and more
 - **MCP Server**: Connect any AI coding agent to your org's governance policies
 - **Centralized Management**: One dashboard to manage configs for Claude Code, Cursor, Windsurf, and more

--- a/docs/merge-rules.md
+++ b/docs/merge-rules.md
@@ -2,7 +2,7 @@
 
 This document defines the reference merge behavior for combining:
 
-- workspace scope from `~/.gal/workspaces/<workspace>/config.yaml`
+- workspace scope from `~/.gal/config.yaml`
 - project scope from `<repo>/.gal/config.yaml`
 
 The effective config is what GAL should use to generate native agent files.

--- a/docs/workspace-model.md
+++ b/docs/workspace-model.md
@@ -1,6 +1,6 @@
-# GAL Workspace Model
+# GAL Local Model
 
-This document defines the target local-first model for the GAL CLI and how that model will be published into the public `gal-run` repository.
+This document describes the current local-first GAL CLI model and the public extraction work around it.
 
 ## Current Public Repo Status
 
@@ -10,21 +10,22 @@ Today this repository is the public home for:
 - installation instructions
 - Homebrew formula
 - issues and community discussion
+- reference helpers, schemas, and tests for the local config model
 
-The CLI source is still being extracted in stages. This document describes the target architecture that public CLI work should implement.
+The CLI source is still being extracted in stages. Public docs should describe the shipped local model, not a future multi-workspace design.
 
-## Scope Model
+## Current Scope Model
 
-GAL should behave as a workspace-scoped configuration layer with repo-scoped overrides.
+GAL currently behaves as a workspace-scoped local config layer with optional repo-scoped overrides.
 
-The intended precedence is:
+The effective precedence is:
 
-`project scope > GAL workspace scope > generated native files`
+`project scope > workspace scope > generated native files`
 
 In practice:
 
-- `~/.gal/workspaces/<workspace>/` stores the local mirror of a GAL workspace
-- `<repo>/.gal/` stores repo-specific overrides
+- `~/.gal/config.yaml` stores the local workspace default
+- `<repo>/.gal/config.yaml` stores repo-specific overrides
 - native files like `AGENTS.md`, `.claude/`, `.cursor/`, and `.github/copilot-instructions.md` are generated outputs
 
 ## Directory Layout
@@ -33,23 +34,9 @@ Workspace scope:
 
 ```text
 ~/.gal/
-  state/
-    config.json
-    current-workspace.json
-    credentials.json
-    update-cache.json
-    telemetry-queue.json
-
-  workspaces/
-    personal/
-      config.yaml
-      platforms/
-      sync-state.json
-
-    scheduler-systems/
-      config.yaml
-      platforms/
-      sync-state.json
+  config.yaml
+  sync-state.json
+  config.json
 ```
 
 Project scope:
@@ -64,25 +51,24 @@ Project scope:
 
 Effective config for a repo should be resolved like this:
 
-1. Load the active workspace config from `~/.gal/workspaces/<workspace>/config.yaml`
+1. Load the workspace config from `~/.gal/config.yaml`
 2. Load repo overrides from `<repo>/.gal/config.yaml` when present
-3. Merge both, with repo scope taking precedence
+3. Use repo scope when the same setting exists in both places
 4. Generate native agent files from the effective config
 
 Important rules:
 
 - repo overrides never silently mutate workspace config
-- workspace sync from GAL Cloud updates `~/.gal/workspaces/<workspace>/`
-- promotion from local state into GAL Cloud or org workflows must be explicit
+- local approval writes the base config to `~/.gal/config.yaml`
+- cloud/org sync can still materialize local config, but repo overrides remain local
 
 ## Command Model
 
 For local-only users:
 
 ```bash
-gal workspace init personal
 gal scan
-gal approve
+gal approve --local
 gal sync
 ```
 
@@ -90,31 +76,29 @@ For connected users:
 
 ```bash
 gal auth login
-gal workspace connect Scheduler-Systems
-gal workspace pull
-gal sync
+gal sync --pull
 ```
 
 For repo-specific overrides:
 
 ```bash
-gal approve --project
 gal sync
 ```
 
+If `<repo>/.gal/config.yaml` exists, it overrides `~/.gal/config.yaml` for that repo.
+
 ## Public Repo Rollout
 
-The public repo rollout should happen in stages:
+The public repo rollout should continue in stages:
 
-1. Publish the scope model and CLI behavior in public docs
-2. Publish shared schemas, config formats, and generated-file mappings
-3. Publish the local config resolver and sync logic that do not require private backend code
-4. Publish the CLI source for local-first flows into this repository
-5. Keep proprietary GAL Cloud and org approval backend logic private
+1. Keep docs, helpers, and tests aligned with the shipped local model
+2. Publish more of the local resolver and sync logic that do not require private backend code
+3. Publish the CLI source for local-first flows into this repository
+4. Keep proprietary GAL Cloud and org approval backend logic private
 
 This keeps the public repo truthful while still allowing incremental extraction of the CLI.
 
-The first public schema drafts live here:
+The current public reference layer includes:
 
 - [schemas/workspace-config.schema.json](../schemas/workspace-config.schema.json)
 - [schemas/project-config.schema.json](../schemas/project-config.schema.json)
@@ -125,10 +109,9 @@ The first public schema drafts live here:
 - [reference/filesystem-helpers.mjs](../reference/filesystem-helpers.mjs)
 - [reference/config-documents.mjs](../reference/config-documents.mjs)
 
-The current public helper layer now also includes:
+The reference helper layer currently covers:
 
-- workspace and project path helpers for `~/.gal/workspaces/<workspace>/` and `<repo>/.gal/`
-- current-workspace state helpers for `~/.gal/state/current-workspace.json`
+- workspace and project path helpers for `~/.gal/` and `<repo>/.gal/`
 - project-root discovery that falls back to `.claude/` and `.gal/` when `.git` is absent
 - raw workspace and project document I/O for YAML config files and JSON sync-state sidecars
 

--- a/reference/config-documents.mjs
+++ b/reference/config-documents.mjs
@@ -68,12 +68,12 @@ function writeJsonDocument(filePath, value) {
   return readJsonDocument(filePath);
 }
 
-export function readWorkspaceConfigDocument(workspaceName, options = {}) {
-  return readTextDocument(getWorkspaceConfigPath(workspaceName, options));
+export function readWorkspaceConfigDocument(options = {}) {
+  return readTextDocument(getWorkspaceConfigPath(options));
 }
 
-export function writeWorkspaceConfigDocument(workspaceName, content, options = {}) {
-  return writeTextDocument(getWorkspaceConfigPath(workspaceName, options), content);
+export function writeWorkspaceConfigDocument(content, options = {}) {
+  return writeTextDocument(getWorkspaceConfigPath(options), content);
 }
 
 export function readProjectConfigDocument(projectRoot) {
@@ -84,12 +84,12 @@ export function writeProjectConfigDocument(projectRoot, content) {
   return writeTextDocument(getProjectConfigPath(projectRoot), content);
 }
 
-export function readWorkspaceSyncState(workspaceName, options = {}) {
-  return readJsonDocument(getWorkspaceSyncStatePath(workspaceName, options));
+export function readWorkspaceSyncState(options = {}) {
+  return readJsonDocument(getWorkspaceSyncStatePath(options));
 }
 
-export function writeWorkspaceSyncState(workspaceName, value, options = {}) {
-  return writeJsonDocument(getWorkspaceSyncStatePath(workspaceName, options), value);
+export function writeWorkspaceSyncState(value, options = {}) {
+  return writeJsonDocument(getWorkspaceSyncStatePath(options), value);
 }
 
 export function readProjectSyncState(projectRoot) {

--- a/reference/config-documents.test.mjs
+++ b/reference/config-documents.test.mjs
@@ -25,11 +25,11 @@ test('workspace config documents round-trip as raw YAML text', () => {
     '',
   ].join('\n');
 
-  const written = writeWorkspaceConfigDocument('personal', content, { homeDir });
+  const written = writeWorkspaceConfigDocument(content, { homeDir });
   assert.equal(written.exists, true);
   assert.equal(written.content, content);
 
-  const readBack = readWorkspaceConfigDocument('personal', { homeDir });
+  const readBack = readWorkspaceConfigDocument({ homeDir });
   assert.deepEqual(readBack, written);
 });
 
@@ -59,11 +59,11 @@ test('workspace sync state round-trips as JSON sidecar data', () => {
     source: 'local',
   };
 
-  const written = writeWorkspaceSyncState('personal', state, { homeDir });
+  const written = writeWorkspaceSyncState(state, { homeDir });
   assert.equal(written.exists, true);
   assert.deepEqual(written.value, state);
 
-  const readBack = readWorkspaceSyncState('personal', { homeDir });
+  const readBack = readWorkspaceSyncState({ homeDir });
   assert.deepEqual(readBack, written);
 });
 
@@ -86,8 +86,8 @@ test('missing config documents return a stable null payload', () => {
   const homeDir = mkdtempSync(join(tmpdir(), 'gal-home-'));
   const projectRoot = mkdtempSync(join(tmpdir(), 'gal-project-'));
 
-  assert.deepEqual(readWorkspaceConfigDocument('personal', { homeDir }), {
-    path: join(homeDir, '.gal', 'workspaces', 'personal', 'config.yaml'),
+  assert.deepEqual(readWorkspaceConfigDocument({ homeDir }), {
+    path: join(homeDir, '.gal', 'config.yaml'),
     exists: false,
     content: null,
   });

--- a/reference/filesystem-helpers.mjs
+++ b/reference/filesystem-helpers.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, parse, resolve } from 'node:path';
 
@@ -33,15 +33,6 @@ function validatePathSegment(name, label) {
   return value;
 }
 
-function firstDefinedValue(values) {
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim();
-    }
-  }
-  return null;
-}
-
 export function getGalRoot({ homeDir = homedir() } = {}) {
   return join(resolve(validatePathString(homeDir, 'Home directory')), '.gal');
 }
@@ -50,75 +41,12 @@ export function getGalStateDir(options = {}) {
   return join(getGalRoot(options), 'state');
 }
 
-export function getCurrentWorkspacePath(options = {}) {
-  return join(getGalStateDir(options), 'current-workspace.json');
+export function getWorkspaceConfigPath(options = {}) {
+  return join(getGalRoot(options), 'config.yaml');
 }
 
-export function getWorkspacesDir(options = {}) {
-  return join(getGalRoot(options), 'workspaces');
-}
-
-export function sanitizeWorkspaceName(name) {
-  return validatePathSegment(name, 'Workspace name');
-}
-
-export function getWorkspaceDir(workspaceName, options = {}) {
-  return join(getWorkspacesDir(options), sanitizeWorkspaceName(workspaceName));
-}
-
-export function getWorkspaceConfigPath(workspaceName, options = {}) {
-  return join(getWorkspaceDir(workspaceName, options), 'config.yaml');
-}
-
-export function getWorkspaceSyncStatePath(workspaceName, options = {}) {
-  return join(getWorkspaceDir(workspaceName, options), 'sync-state.json');
-}
-
-export function readCurrentWorkspaceSelection(options = {}) {
-  const statePath = getCurrentWorkspacePath(options);
-  if (!existsSync(statePath)) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(readFileSync(statePath, 'utf-8'));
-    return typeof parsed.workspace === 'string' && parsed.workspace.trim()
-      ? sanitizeWorkspaceName(parsed.workspace)
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-export function writeCurrentWorkspaceSelection(workspaceName, options = {}) {
-  const stateDir = getGalStateDir(options);
-  mkdirSync(stateDir, { recursive: true });
-  const payload = {
-    workspace: sanitizeWorkspaceName(workspaceName),
-  };
-  writeFileSync(
-    getCurrentWorkspacePath(options),
-    `${JSON.stringify(payload, null, 2)}\n`,
-    'utf-8'
-  );
-}
-
-export function resolveActiveWorkspace({
-  explicitWorkspace,
-  projectWorkspaceRef,
-  gitOwner,
-  currentWorkspace,
-  fallbackWorkspace = 'personal',
-} = {}) {
-  const selected = firstDefinedValue([
-    explicitWorkspace,
-    projectWorkspaceRef,
-    gitOwner,
-    currentWorkspace,
-    fallbackWorkspace,
-  ]);
-
-  return sanitizeWorkspaceName(selected || 'personal');
+export function getWorkspaceSyncStatePath(options = {}) {
+  return join(getGalRoot(options), 'sync-state.json');
 }
 
 export function getProjectGalDir(projectRoot) {

--- a/reference/filesystem-helpers.test.mjs
+++ b/reference/filesystem-helpers.test.mjs
@@ -1,73 +1,25 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
 import {
   findProjectRoot,
-  getCurrentWorkspacePath,
   getProjectConfigPath,
   getWorkspaceConfigPath,
-  readCurrentWorkspaceSelection,
-  resolveActiveWorkspace,
-  writeCurrentWorkspaceSelection,
+  getWorkspaceSyncStatePath,
 } from './filesystem-helpers.mjs';
 
-test('workspace helper paths use ~/.gal/workspaces/<workspace>', () => {
+test('workspace helper paths use ~/.gal/config.yaml and ~/.gal/sync-state.json', () => {
   const homeDir = '/tmp/gal-home';
   assert.equal(
-    getWorkspaceConfigPath('scheduler-systems', { homeDir }),
-    '/tmp/gal-home/.gal/workspaces/scheduler-systems/config.yaml'
+    getWorkspaceConfigPath({ homeDir }),
+    '/tmp/gal-home/.gal/config.yaml'
   );
   assert.equal(
-    getCurrentWorkspacePath({ homeDir }),
-    '/tmp/gal-home/.gal/state/current-workspace.json'
-  );
-});
-
-test('current workspace selection round-trips through ~/.gal/state/current-workspace.json', () => {
-  const homeDir = mkdtempSync(join(tmpdir(), 'gal-home-'));
-
-  writeCurrentWorkspaceSelection('scheduler-systems', { homeDir });
-
-  assert.equal(
-    readCurrentWorkspaceSelection({ homeDir }),
-    'scheduler-systems'
-  );
-
-  const statePath = getCurrentWorkspacePath({ homeDir });
-  const raw = JSON.parse(readFileSync(statePath, 'utf-8'));
-  assert.deepEqual(raw, { workspace: 'scheduler-systems' });
-});
-
-test('resolveActiveWorkspace honors explicit, project, git, current, then fallback order', () => {
-  assert.equal(
-    resolveActiveWorkspace({
-      explicitWorkspace: 'explicit',
-      projectWorkspaceRef: 'project',
-      gitOwner: 'owner',
-      currentWorkspace: 'current',
-      fallbackWorkspace: 'personal',
-    }),
-    'explicit'
-  );
-
-  assert.equal(
-    resolveActiveWorkspace({
-      projectWorkspaceRef: 'project',
-      gitOwner: 'owner',
-      currentWorkspace: 'current',
-      fallbackWorkspace: 'personal',
-    }),
-    'project'
-  );
-
-  assert.equal(
-    resolveActiveWorkspace({
-      currentWorkspace: 'current',
-    }),
-    'current'
+    getWorkspaceSyncStatePath({ homeDir }),
+    '/tmp/gal-home/.gal/sync-state.json'
   );
 });
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -36,7 +36,7 @@ try {
     Write-Host ""
     Write-Host "Next steps:"
     Write-Host "  gal scan              # Discover local AI agent configs"
-    Write-Host "  gal approve --local   # Standardize into .gal/config.yaml"
+    Write-Host "  gal approve --local   # Standardize into ~/.gal/config.yaml"
     Write-Host "  gal sync              # Distribute to your coding agents"
     Write-Host ""
     Write-Host "Optional org sync:"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ if command -v gal &> /dev/null; then
     echo ""
     echo "Next steps:"
     echo "  gal scan              # Discover local AI agent configs"
-    echo "  gal approve --local   # Standardize into .gal/config.yaml"
+    echo "  gal approve --local   # Standardize into ~/.gal/config.yaml"
     echo "  gal sync              # Distribute to your coding agents"
     echo ""
     echo "Optional org sync:"


### PR DESCRIPTION
Closes #130

## Summary
- align the public local model with the shipped single-workspace config path under `~/.gal/config.yaml`
- update the public README, local-model docs, and installer next-step copy
- simplify the public reference helpers/tests so workspace config and sync-state live directly under `~/.gal/`

## Verification
- `node --test /Users/scheduler-systems/work/gal-run/reference/*.test.mjs`
- `git -C /Users/scheduler-systems/work/gal-run diff --check`
