### PR TITLE
docs: clarify ELv2 licensing in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,8 @@
-© Scheduler Systems Ltd. All rights reserved. Use is subject to Scheduler Systems' [Terms of Service](https://gal.run/terms).
+Copyright (c) Scheduler Systems Ltd.
+
+This repository is licensed under the Elastic License 2.0 (ELv2).
+
+See the full license text at:
+https://www.elastic.co/licensing/elastic-license
+
+Use of the hosted GAL service is also subject to Scheduler Systems' [Terms of Service](https://gal.run/terms).


### PR DESCRIPTION
Addresses #151

## Summary
- replace the old all-rights-reserved notice with an explicit ELv2 notice
- keep the hosted GAL service terms link for the SaaS offering

## Testing
- not run (documentation-only change)