### PR TITLE
fix: auto-merge release PRs instead of leaving them open (#5770)

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -205,12 +205,16 @@ jobs:
             EXISTING_PR=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --base main --state open --json url --jq '.[0].url')
             if [ -n "$EXISTING_PR" ]; then
               echo "Release PR already open: $EXISTING_PR"
+              PR_URL="$EXISTING_PR"
             else
-              gh pr create --base main --head "$BRANCH" \
+              PR_URL=$(gh pr create --base main --head "$BRANCH" \
                 --title "Release v$VERSION" \
-                --body "Automated release version update. Manual review is required before merge." \
-                --repo "${{ github.repository }}"
+                --body "Automated release version update." \
+                --repo "${{ github.repository }}")
+              echo "Created PR: $PR_URL"
             fi
+            # Auto-merge the release PR
+            gh pr merge "$PR_URL" --squash --admin --delete-branch --repo "${{ github.repository }}"
           else
             echo "No changes to commit - version already up to date"
           fi


### PR DESCRIPTION
## Summary

The `sync-release.yml` workflow creates PRs to update version references (README, CHANGELOG, Homebrew formula/cask) but never auto-merges them. This leaves unmerged release PRs accumulating in the repository.

**Changes:**
- Capture the PR URL from both the existing-PR and new-PR code paths
- Auto-merge the release PR with `--squash --admin --delete-branch`

Fixes #5770

## Test plan

- [ ] Trigger a release from the upstream workflow and verify the sync-release PR is created **and** auto-merged
- [ ] Verify the release branch is deleted after merge
- [ ] Verify that if a release PR already exists (open), it is also auto-merged
