### PR TITLE
Migrate stale-issue-manager to self-hosted ci-standard

### DIFF
--- a/.github/workflows/stale-issue-manager.yml
+++ b/.github/workflows/stale-issue-manager.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ci-standard
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
## Summary
- Migrate stale-issue-manager.yml from `ubuntu-latest` to `ci-standard`

## Why
Shay confirmed all workflows should run through Stratus. Saves ~4 min/mo (low frequency, 1x/day).

## Test plan
- [ ] Verify stale job runs on ci-standard runner next scheduled trigger