### PR TITLE
[codex] Add GAL status page entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://github.com/Scheduler-Systems/gal-run/issues"><img src="https://img.shields.io/github/issues/Scheduler-Systems/gal-run" alt="GitHub issues"></a>
   <a href="https://gal.run"><img src="https://img.shields.io/badge/docs-gal.run-blue" alt="Documentation"></a>
+  <a href="https://status.scheduler-systems.com"><img src="https://img.shields.io/badge/status-scheduler--systems-green" alt="Service status"></a>
 </p>
 
 # GAL - Governance Agentic Layer
@@ -14,6 +15,20 @@ The easiest way to govern your AI coding agents.
 GAL provides centralized configuration management and governance for AI coding agents (Claude Code, Cursor, Windsurf, GitHub Copilot, and more) without disrupting your developers or requiring an architecture overhaul.
 
 **[Get started free at app.gal.run](https://app.gal.run)**
+
+## Service Status
+
+GAL service health is published through the Scheduler Systems status page:
+
+- **Status page:** [status.scheduler-systems.com](https://status.scheduler-systems.com)
+- **Machine-readable status:** [status.scheduler-systems.com/status.json](https://status.scheduler-systems.com/status.json)
+- **Component map:** [docs/status-components.md](docs/status-components.md)
+
+Customer-facing status components currently include GAL API, GAL Code Gateway,
+GLM Gateway, Agent Network, GAL-T, extension services, CLI distribution, and
+release/update services. When GAL APIs report degraded service, product and
+client surfaces should show service-degradation messaging instead of implying
+user misconfiguration.
 
 ## CLI
 
@@ -252,6 +267,7 @@ Access your organization's dashboard at [app.gal.run](https://app.gal.run)
 
 - **Issues**: Use this repository for bug reports and feature requests
 - **Discussions**: Community support and questions
+- **Status**: Check [status.scheduler-systems.com](https://status.scheduler-systems.com) for service incidents
 - **Email**: support@scheduler-systems.com
 - **Enterprise**: For enterprise inquiries, contact sales@scheduler-systems.com
 

--- a/docs/status-components.md
+++ b/docs/status-components.md
@@ -1,0 +1,67 @@
+# GAL Status Components
+
+GAL status is published through the central Scheduler Systems status page:
+`https://status.scheduler-systems.com`.
+
+This document maps GAL product capabilities to customer-facing status
+components. Component names should match the Stratus status catalog so support,
+client UX, synthetic probes, and incident updates use the same language.
+
+## Public Components
+
+| Component | Customer path | Owning source | Public status meaning |
+| --- | --- | --- | --- |
+| GAL API | `https://api.gal.run` authenticated REST/MCP/API traffic | `gal-run/gal-private` | GAL control-plane API availability, auth/API routing, and safe request correlation |
+| GAL Code Gateway | `https://api.gal.run/api/gal-code/*` OpenAI-compatible GAL Code traffic | `gal-run/gal-private` | Gateway availability, retryable upstream failures, timeout handling, and safe upstream metadata |
+| GLM Gateway | GLM model route behind GAL Code | `gal-run/gal-private` | Upstream model/provider availability, throttling, and dependency degradation |
+| GAL Web App | `https://app.gal.run` authenticated product UI | `gal-run/gal-private` | Dashboard availability and authenticated GAL workflows |
+| GAL CLI Distribution | install/update channels for `gal` | `gal-run/gal-cli` and release automation | CLI install/update availability, package registry health, and release artifact access |
+| VS Code Extension | GAL VS Code extension runtime and update path | `gal-run/gal-vscode-extension` | Extension update availability and API service-degradation UX |
+| Browser Extension | GAL browser extension runtime and update path | `gal-run/gal-browser-extension` | Extension update availability, sync retries, and API service-degradation UX |
+| Agent Network | Agent Network APIs and SDK-facing service boundary | `gal-run/agent-network` | API availability, SDK-safe degraded dependency metadata, and request correlation |
+| GAL-T | GAL-T gateway deployments | `gal-run/gal-t` | Gateway availability, policy engine availability, queue/backpressure, and safe connectivity state |
+
+## Client UX Rules
+
+- Show the canonical status-page link when a GAL API returns safe degradation
+  metadata.
+- Preserve request IDs and retry-after values in support-visible messages.
+- Treat `429`, `500`, `502`, `503`, `504`, network failures, and upstream
+  timeouts as service states when the API marks them as gateway/upstream
+  degradation.
+- Do not tell users to re-authenticate, reinstall, or change local config when
+  the service is reporting degraded or unavailable state.
+- Do not expose provider secrets, prompts, tenant identifiers, policy payloads,
+  internal project names, raw stack traces, or unredacted upstream responses.
+
+## Status Endpoint Contract
+
+Product services should expose:
+
+- `/healthz` for process/liveness checks.
+- `/readyz` for deployment readiness and required local dependencies.
+- `/status` for machine-readable public component state, dependency state, and
+  safe diagnostic metadata.
+
+Public `/status` output should include only:
+
+- component name
+- status value
+- generated timestamp
+- request/correlation ID where applicable
+- dependency status family, not secret dependency details
+- retry-after or maintenance window when available
+- status-page URL
+
+Internal dashboards can hold richer operator-only fields, but those fields must
+not be required for customer support to triage degraded-service reports.
+
+## Related Work
+
+- Stratus parent status feature: `StratusCloudLabs/stratus#3283`
+- Stratus status-page seed PR: `StratusCloudLabs/stratus#3285`
+- GAL Gateway diagnostics: `gal-run/gal-private#6921`
+- GAL Gateway implementation PR: `gal-run/gal-private#6923`
+- GAL CLI status command: `gal-run/gal-cli#7`
+- VS Code service-degradation UX: `gal-run/gal-vscode-extension#3`
+- Browser service-degradation UX: `gal-run/gal-browser-extension#3`


### PR DESCRIPTION
## Summary
- add a public service-status badge and section to the GAL README
- document the customer-facing GAL status component map and client UX rules
- link GAL support readers to the canonical Scheduler Systems status page and machine-readable `status.json`

## Why
GAL product surfaces need obvious status-page entry points and shared component names so users do not confuse GAL API/Gateway degradation with local auth or configuration problems.

## Validation
- `git diff --check`

Addresses gal-run/[internal-repo]
Refs [internal-infra]
Refs [internal-infra]
Refs gal-run/[internal-service]
Refs gal-run/[internal-repo]
