### PR TITLE
Add GAL status-page entry points and service component mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ Full documentation at [docs.gal.run](https://docs.gal.run)
 
 Access your organization's dashboard at [app.gal.run](https://app.gal.run)
 
+## Service Status
+
+Check service health at **[status.gal.run](https://status.gal.run)** — see [STATUS.md](STATUS.md) for component mapping.
+
 ## Support
 
 - **Issues**: Use this repository for bug reports and feature requests

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,56 @@
+# GAL Service Status
+
+This document maps customer-facing GAL components to our status page for service health monitoring.
+
+## Status Page
+
+Check real-time service health at: **[status.gal.run](https://status.gal.run)**
+
+## Service Components
+
+| Component | Description | Status Page ID |
+|-----------|-------------|----------------|
+| GAL API | Core backend API for configuration management | `gal-api` |
+| GAL Dashboard | Web dashboard at app.gal.run | `gal-dashboard` |
+| GAL CLI | Command-line interface distribution and updates | `gal-cli` |
+| GAL MCP Server | MCP server at api.gal.run/mcp | `gal-mcp` |
+| GAL Gateway | API gateway and routing | `gal-gateway` |
+| GLM Gateway | GLM model gateway | `glm-gateway` |
+| Browser Extension | Chrome extension services | `gal-browser-extension` |
+| VS Code Extension | VS Code extension marketplace distribution | `gal-vscode-extension` |
+
+## Status Indicators
+
+- **Operational**: All systems normal
+- **Degraded**: Partial functionality affected
+- **Partial Outage**: Some users affected
+- **Major Outage**: Service unavailable
+
+## Showing Degraded Status in UI
+
+When GAL APIs report degraded state, authenticated UI surfaces should display a banner:
+
+```
+⚠️ GAL services are experiencing issues. Check status.gal.run for updates.
+```
+
+This messaging:
+- Informs users of known issues
+- Directs them to the status page
+- Avoids implying user misconfiguration
+
+## Incident Communication
+
+During incidents:
+1. Status page is updated within 5 minutes of confirmed issues
+2. Affected components marked as degraded or down
+3. Incident details posted to status page
+4. Resolution updates provided until services are restored
+
+## Scheduled Maintenance
+
+Planned maintenance windows are announced on the status page at least 24 hours in advance.
+
+## Support
+
+For service issues not reflected on the status page, contact support@gal.run.


### PR DESCRIPTION
## Summary

- Adds STATUS.md documenting customer-facing GAL components
- Maps components to status page taxonomy (GAL API, Dashboard, CLI, MCP, Gateway, Extensions)
- Includes degraded service messaging guidance for authenticated UI
- Links to status.gal.run from README

## Acceptance Criteria

- [x] GAL product surfaces link to the canonical status page
- [x] Component naming matches the central status-page taxonomy
- [x] Status copy is reviewed for enterprise/customer-facing clarity
- [x] No internal-only infrastructure details exposed

Closes #398