### PR TITLE
Governance: repo tier registry + Definition of Moat + anti-drift charter gate

### DIFF
--- a/.gal/charter.yaml
+++ b/.gal/charter.yaml
@@ -1,0 +1,7 @@
+# Generated from gal/governance/REGISTRY.yaml — edit the registry, then re-stamp.
+# First dogfood charter: the governance hub governs itself.
+repo: cli/gal
+tier: core
+moat: true
+purpose: Governance docs + contracts hub (home of the repo registry + Definition of Moat).
+owner: TBD

--- a/.github/workflows/charter-check.yml
+++ b/.github/workflows/charter-check.yml
@@ -1,0 +1,26 @@
+name: charter-check
+# Anti-drift gate: validates governance/REGISTRY.yaml self-consistency on every PR.
+# (Org-wide per-repo charter validation runs in the gal-cli hook / a scheduled org job
+#  with all repos checked out under one root; see governance/DEFINITION-OF-MOAT.md.)
+on:
+  pull_request:
+    paths:
+      - "governance/**"
+      - ".gal/charter.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "governance/**"
+      - ".gal/charter.yaml"
+  workflow_dispatch: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      - run: python governance/charters.py check

--- a/governance/DEFINITION-OF-MOAT.md
+++ b/governance/DEFINITION-OF-MOAT.md
@@ -1,0 +1,55 @@
+# GAL Definition of Moat — and the anti-drift gate
+
+GAL exists to be the **governance control plane for AI agents**: *who is allowed to
+run what, did it pass the gates, who approved the mutation, is it compliant, did it
+drift.* Everything else is data plane that mature products already own.
+
+This doc is the policy the charter checker (`governance/charters.py`) and CI enforce.
+It is dogfood: we govern our own org with our own control plane.
+
+## What is the moat (BUILD)
+A repo is moat (`moat: true`, eligible for `tier: core`) only if it is one of:
+- **Policy + enforcement** — defining and *enforcing* what agents may do (gal-mcp, governance-svc, gal-cli-rs, gal-sandbox).
+- **Constitution / root-of-trust** — si-bootstrap.
+- **Governance contracts** — agent cards, task/eval-gate/report schemas, interop profiles (gal-agents, agent-network, gal-evals *gate*).
+- **Cross-runtime capture + audit** — hooks that observe/govern output from any runtime.
+- **Governance-specific decisioning/proof** — gal-model (learned advisory), gal-benchmark (proof), gal-swarm/gal-prediction (governed dispatch).
+
+## What is NOT the moat (INTEGRATE / BUNDLE — do not rebuild)
+If a capability maps to any of these commodity categories, it must be `tier: integrate`
+with `integrates:` naming the product we use instead — or it is rejected:
+- Evals / scoring → DeepEval, openevals, Ragas
+- Observability / tracing → OpenTelemetry, Langfuse (self-host), LangSmith
+- Computer/browser/IDE/terminal automation → Anthropic computer-use, Playwright, node-pty
+- Coding agents → Claude Code, Cursor, Codex
+- Model serving / generic ML infra, generic terminal/UI shells, feature-flag/entitlement UIs
+
+Rationale: rebuilding these is a permanent treadmill behind better-funded teams and
+dilutes the only thing nobody else will build. Bundle self-hosted OSS for a cheaper
+default; integrate the proprietary leaders for customers who already use them.
+
+## The four tiers
+| Tier | Meaning | Requirement |
+|------|---------|-------------|
+| `core` | governance moat or required infra | `moat: true` (except explicitly-tagged required infra, e.g. marketing site) |
+| `integrate` | commodity capability | `integrates: <product>` set; retire the rebuild, keep only the thin governance hook |
+| `experimental` | governance-relevant research, pre-production | `review_by: <future date>`; off the production critical path |
+| `archive` | off-mission / superseded | read-only; do not depend on it |
+
+## The anti-drift gate (how we don't drift again)
+1. **Every repo MUST carry `.gal/charter.yaml`** matching its registry entry. CI fails without one.
+2. **`tier: core` requires `moat: true`.** A core claim that isn't moat is a drift violation.
+3. **New repos / major new capabilities require an approved charter before first merge.**
+   If the capability is a commodity category above, the charter must justify why no
+   integration/bundle works — approved only by the **moat guardian**.
+4. **Quarterly re-attestation.** An `experimental` charter past its `review_by`, or any
+   charter whose reality diverged from its tier, surfaces as a **drift alert** in
+   gal-dashboard. Drift is a tracked item, not a vibe.
+5. **Enforced by our own stack**, not willpower:
+   - `si-bootstrap`: a "governance-first / no commodity rebuild" pillar.
+   - `governance-svc`: a policy rule evaluating charters across the org.
+   - `gal-cli-rs` hook + the `charter-check` CI: block merges lacking a valid charter
+     or adding a known commodity-rebuild dependency without an approved exception.
+
+> If GAL can't keep itself from drifting with its own control plane, that's the loudest
+> possible signal about the product. If it can, that's the best demo we have.

--- a/governance/REGISTRY.yaml
+++ b/governance/REGISTRY.yaml
@@ -1,0 +1,205 @@
+# GAL org repository registry — the single source of truth for repo tiers.
+#
+# Tiers (see governance/DEFINITION-OF-MOAT.md):
+#   core         — the governance moat or required infra. Private/production.
+#   integrate    — commodity capability; integrate/bundle a standard product
+#                  instead of maintaining a rebuild. Must set `integrates`.
+#   experimental — governance-relevant research, pre-production. Must set `review_by`.
+#   archive      — off-mission / superseded. Read-only.
+#
+# Rules enforced by governance/charters.py (and CI):
+#   - tier=core         REQUIRES moat: true
+#   - tier=integrate    REQUIRES integrates: <product>
+#   - tier=experimental REQUIRES review_by: <future date>
+# Generated audit: 2026-06-03 (multi-agent governance-drift audit).
+
+version: 1
+updated: 2026-06-03
+
+repos:
+  # ---- core (15): the governance moat + required infra ----
+  - repo: core/si-bootstrap
+    tier: core
+    moat: true
+    purpose: Immutable constitutional root-of-trust (six pillars) governing all agent layers.
+    owner: TBD
+  - repo: mcp/gal-mcp
+    tier: core
+    moat: true
+    purpose: Policy/enforcement control plane MCP (proposals, compliance, approval gates).
+    owner: TBD
+  - repo: cli/gal-cli-rs
+    tier: core
+    moat: true
+    purpose: Rust enforcement engine — config scan/sync, policy hooks, audit, MCP exposure.
+    owner: TBD
+  - repo: cli/gal
+    tier: core
+    moat: true
+    purpose: Governance docs + contracts hub (home of this registry).
+    owner: TBD
+  - repo: platform/gal-sandbox
+    tier: core
+    moat: true
+    purpose: OS-level enforcement boundary (seccomp/AppArmor/cap-drop) for agent execution.
+    owner: TBD
+  - repo: platform/gal-benchmark
+    tier: core
+    moat: true
+    purpose: Vendor-neutral governance benchmark proving GAL's claims at scale.
+    owner: TBD
+  - repo: platform/gal-swarm
+    tier: core
+    moat: true
+    purpose: Governed burst-compute planning (scale/hold/drain) with evidence ledger.
+    owner: TBD
+  - repo: backend/gal-model
+    tier: core
+    moat: true
+    purpose: Learned governance advisory decision model over the audit ledger.
+    owner: TBD
+  - repo: backend/gal-prediction
+    tier: core
+    moat: true
+    purpose: Execution/capacity forecasting that gates dispatch decisions.
+    owner: TBD
+  - repo: backend/go-services
+    tier: core
+    moat: true
+    purpose: Governance control-plane backbone (governance/dispatch/telemetry/mal/sdlc svc).
+    owner: TBD
+  - repo: backend/gal-evals
+    tier: core
+    moat: true
+    purpose: Eval-gate CONTRACT (suite/report schema + deploy gate). Bundles DeepEval as engine.
+    owner: TBD
+  - repo: core/agent-network
+    tier: core
+    moat: true
+    purpose: Canonical agent-card + task/artifact contracts + transport interop (A2A/MCP).
+    owner: TBD
+  - repo: core/gal-agents
+    tier: core
+    moat: true
+    purpose: Canonical agent-card / task-contract definitions used across products.
+    owner: TBD
+  - repo: web/gal-dashboard
+    tier: core
+    moat: true
+    purpose: Governance UI — policy, approval gates, audit/evidence, drift, compliance.
+    owner: TBD
+  - repo: web/gal-website
+    tier: core
+    moat: false
+    purpose: Marketing + docs site (required infra, not moat).
+    owner: TBD
+
+  # ---- integrate (9): retire the rebuild, bundle/integrate the standard product ----
+  - repo: mcp/gal-browser-use-mcp
+    tier: integrate
+    moat: false
+    integrates: Playwright / Anthropic computer-use (keep only the Chrome-extension governance hook)
+    competes_with: Playwright, browser-use, Anthropic computer-use
+    purpose: Browser automation MCP.
+    owner: TBD
+  - repo: mcp/gal-computer-use-mcp
+    tier: integrate
+    moat: false
+    integrates: Anthropic computer-use
+    competes_with: Anthropic computer-use, UITars, pyautogui
+    purpose: Screen/OS control MCP.
+    owner: TBD
+  - repo: mcp/gal-ide-use-mcp
+    tier: integrate
+    moat: false
+    integrates: Cursor / VS Code API
+    competes_with: Cursor, Playwright Electron
+    purpose: VS Code automation MCP.
+    owner: TBD
+  - repo: mcp/gal-terminal-use-mcp
+    tier: integrate
+    moat: false
+    integrates: raw shell via gal-cli audit hooks
+    competes_with: node-pty, expect
+    purpose: Terminal/PTY automation MCP.
+    owner: TBD
+  - repo: platform/gal-accessibility-app
+    tier: integrate
+    moat: false
+    integrates: Anthropic computer-use / Playwright
+    competes_with: computer-use, Playwright
+    purpose: macOS accessibility desktop automation helper.
+    owner: TBD
+  - repo: platform/gal-chrome-extension
+    tier: integrate
+    moat: false
+    integrates: thin policy-delivery wrapper over gal-mcp
+    competes_with: Cursor sidebar, Claude Code UI
+    purpose: In-browser policy/command delivery surface.
+    owner: TBD
+  - repo: backend/gal-admin
+    tier: integrate
+    moat: false
+    integrates: standard entitlement/feature-flag platform
+    competes_with: feature-flag / user-mgmt UIs
+    purpose: Entitlement/feature-access admin UI.
+    owner: TBD
+  - repo: core/agent-git-graph
+    tier: integrate
+    moat: false
+    integrates: fold into gal-cli as a workspace-governance feature
+    competes_with: none
+    purpose: Terminal Git/worktree visualization for agent sessions.
+    owner: TBD
+  - repo: extensions/gal-code
+    tier: integrate
+    moat: false
+    integrates: Claude Code / Cursor / Codex (consume them under governance, keep the runtime hook)
+    competes_with: Claude Code, Cursor, Windsurf
+    purpose: First-party AI coding agent.
+    owner: TBD
+
+  # ---- experimental (4): governance research, pre-production ----
+  - repo: core/agent-civilization
+    tier: experimental
+    moat: false
+    review_by: 2026-09-01
+    purpose: Self-governing agent collectives within constitutional bounds (prototype).
+    owner: TBD
+  - repo: core/agent-economy
+    tier: experimental
+    moat: false
+    review_by: 2026-09-01
+    purpose: Autonomous agent-to-agent contracts/escrow within financial caps (prototype).
+    owner: TBD
+  - repo: core/agent-os
+    tier: experimental
+    moat: false
+    review_by: 2026-09-01
+    purpose: Declarative agent runtime with policy enforcement + self-improvement (prototype).
+    owner: TBD
+  - repo: core/super-agent
+    tier: experimental
+    moat: false
+    review_by: 2026-09-01
+    purpose: Meta-reasoning orchestration with constitution-gated aggregation (prototype).
+    owner: TBD
+
+  # ---- archive (3): off-mission / superseded ----
+  - repo: core/agent-federation
+    tier: archive
+    moat: false
+    purpose: Cross-operator federation research; must not block centralized fabric. Park.
+    owner: TBD
+  - repo: tools/demo-studio
+    tier: archive
+    moat: false
+    competes_with: Screen Studio, Camtasia
+    purpose: AI demo-video recorder; out of governance scope. Use a 3rd-party tool.
+    owner: TBD
+  - repo: web/gal-app
+    tier: archive
+    moat: false
+    competes_with: Warp, iTerm
+    purpose: Warp-fork terminal client; commodity UX, no governance value.
+    owner: TBD

--- a/governance/charter.schema.yaml
+++ b/governance/charter.schema.yaml
@@ -1,0 +1,13 @@
+# Schema for a per-repo .gal/charter.yaml (informational; enforced by charters.py).
+# Every GAL org repo must commit one of these at .gal/charter.yaml.
+
+repo: string            # "group/name", must match an entry in REGISTRY.yaml
+tier: enum              # core | integrate | experimental | archive
+moat: bool              # true only for governance moat (see DEFINITION-OF-MOAT.md)
+purpose: string         # one line
+owner: string           # accountable human (not "TBD" once assigned)
+
+# Conditionally required:
+integrates: string      # REQUIRED when tier == integrate (the product used instead of rebuilding)
+review_by: date         # REQUIRED when tier == experimental (YYYY-MM-DD, must be in the future)
+competes_with: string   # optional: the commodity product this would otherwise duplicate

--- a/governance/charters.py
+++ b/governance/charters.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""GAL repo-charter tooling — the anti-drift enforcement primitive.
+
+Subcommands:
+  check   Validate REGISTRY.yaml self-consistency and (optionally) per-repo
+          .gal/charter.yaml files under an org root. Exits non-zero on any
+          violation so it can gate CI / a gal-cli hook.
+  stamp   Generate/refresh .gal/charter.yaml in each repo from REGISTRY.yaml
+          (single source of truth -> materialized per-repo charters).
+
+Tier rules (see DEFINITION-OF-MOAT.md):
+  tier=core         -> moat must be true (unless explicitly required-infra)
+  tier=integrate    -> integrates must be set
+  tier=experimental -> review_by must be a future date
+  tier=archive      -> no extra requirement
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+from pathlib import Path
+
+import yaml
+
+VALID_TIERS = {"core", "integrate", "experimental", "archive"}
+HERE = Path(__file__).resolve().parent
+REGISTRY = HERE / "REGISTRY.yaml"
+# Repos that are core required-infra but legitimately not the moat.
+CORE_INFRA_EXCEPTIONS = {"web/gal-website"}
+
+
+def _load_registry() -> list[dict]:
+    data = yaml.safe_load(REGISTRY.read_text())
+    return data.get("repos", [])
+
+
+def _violations_for(entry: dict, *, where: str) -> list[str]:
+    """Tier-rule violations for one repo entry (registry row or charter)."""
+    out: list[str] = []
+    repo = entry.get("repo", "<missing repo>")
+    tier = entry.get("tier")
+    if tier not in VALID_TIERS:
+        out.append(f"{where}: {repo}: invalid/missing tier {tier!r}")
+        return out
+    if tier == "core" and not entry.get("moat") and repo not in CORE_INFRA_EXCEPTIONS:
+        out.append(f"{where}: {repo}: tier=core requires moat:true (or required-infra exception)")
+    if tier == "integrate" and not entry.get("integrates"):
+        out.append(f"{where}: {repo}: tier=integrate requires `integrates:`")
+    if tier == "experimental":
+        rb = entry.get("review_by")
+        if not rb:
+            out.append(f"{where}: {repo}: tier=experimental requires `review_by:`")
+        else:
+            try:
+                d = rb if isinstance(rb, dt.date) else dt.date.fromisoformat(str(rb))
+                if d <= dt.date.today():
+                    out.append(f"{where}: {repo}: experimental review_by {d} is past — re-attest or retier (DRIFT)")
+            except ValueError:
+                out.append(f"{where}: {repo}: review_by {rb!r} is not YYYY-MM-DD")
+    return out
+
+
+def cmd_check(root: str | None) -> int:
+    registry = _load_registry()
+    by_repo = {e["repo"]: e for e in registry}
+    violations: list[str] = []
+
+    # 1. registry self-consistency
+    for e in registry:
+        violations += _violations_for(e, where="registry")
+
+    # 2. per-repo charters (when an org root is given): each registry repo must
+    #    have a .gal/charter.yaml that matches its registry tier.
+    if root:
+        root_p = Path(root)
+        for repo, e in by_repo.items():
+            charter_p = root_p / repo / ".gal" / "charter.yaml"
+            if not charter_p.exists():
+                violations.append(f"charter: {repo}: missing .gal/charter.yaml")
+                continue
+            try:
+                c = yaml.safe_load(charter_p.read_text()) or {}
+            except yaml.YAMLError as exc:
+                violations.append(f"charter: {repo}: unparseable charter ({exc})")
+                continue
+            violations += _violations_for(c, where="charter")
+            if c.get("tier") != e.get("tier"):
+                violations.append(
+                    f"charter: {repo}: tier {c.get('tier')!r} != registry {e.get('tier')!r}"
+                )
+
+    if violations:
+        print("CHARTER CHECK FAILED:")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    n = len(registry)
+    scope = f" + {n} per-repo charters" if root else ""
+    print(f"charter check OK — {n} registry entries{scope} valid.")
+    return 0
+
+
+def cmd_stamp(root: str) -> int:
+    """Write .gal/charter.yaml into each repo from the registry."""
+    root_p = Path(root)
+    written = 0
+    for e in _load_registry():
+        repo = e["repo"]
+        repo_dir = root_p / repo
+        if not repo_dir.exists():
+            print(f"  skip {repo}: not found under {root}")
+            continue
+        charter = {k: e[k] for k in ("repo", "tier", "moat", "purpose", "owner") if k in e}
+        for opt in ("integrates", "review_by", "competes_with"):
+            if e.get(opt):
+                charter[opt] = e[opt]
+        out_dir = repo_dir / ".gal"
+        out_dir.mkdir(exist_ok=True)
+        (out_dir / "charter.yaml").write_text(
+            "# Generated from gal/governance/REGISTRY.yaml — edit the registry, then re-stamp.\n"
+            + yaml.safe_dump(charter, sort_keys=False, allow_unicode=True)
+        )
+        written += 1
+    print(f"stamped {written} charters under {root}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="GAL repo-charter anti-drift tooling")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    pc = sub.add_parser("check", help="validate registry + per-repo charters")
+    pc.add_argument("--root", help="org root containing group/repo dirs (validates charters)")
+    ps = sub.add_parser("stamp", help="generate per-repo charters from the registry")
+    ps.add_argument("--root", required=True, help="org root containing group/repo dirs")
+    args = p.parse_args()
+    if args.cmd == "check":
+        return cmd_check(args.root)
+    if args.cmd == "stamp":
+        return cmd_stamp(args.root)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Turns the org-wide governance-drift audit into an enforceable system — GAL governing its own repos with its own control plane.

**Adds (`governance/`):**
- `REGISTRY.yaml` — single source of truth tiering all 31 gal-run repos: **15 core · 9 integrate · 4 experimental · 3 archive**.
- `DEFINITION-OF-MOAT.md` — what to BUILD (governance/enforcement/contracts/cross-runtime) vs INTEGRATE/BUNDLE (evals, observability, computer/browser/IDE/terminal automation, coding agents, model serving), the 4 tiers, and the anti-drift gate.
- `charter.schema.yaml` + `charters.py` (`check`/`stamp`) — validates registry + per-repo `.gal/charter.yaml`; enforces tier rules (core⇒moat, integrate⇒integrates, experimental⇒future review_by).
- `.github/workflows/charter-check.yml` — CI gate.
- `.gal/charter.yaml` — first dogfood charter (cli/gal itself).

**Prevents re-drift:** every repo must carry a charter matching the registry; `tier:core` requires `moat:true`; new repos need an approved charter before merge; experimental charters expire → drift surfaces as a dashboard item.

Follow-ups (not here): `stamp` the 31 per-repo charters, wire the check into gal-cli-rs + governance-svc, archive the 3 archive-tier repos (held — destructive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)