### PR TITLE
Re-tier archive repos per owner: zero archives (#414)

### DIFF
--- a/governance/REGISTRY.yaml
+++ b/governance/REGISTRY.yaml
@@ -185,21 +185,25 @@ repos:
     purpose: Meta-reasoning orchestration with constitution-gated aggregation (prototype).
     owner: TBD
 
-  # ---- archive (3): off-mission / superseded ----
+  # ---- re-tiered 2026-06-03 per owner: NONE archived ----
+  # agent-federation + gal-app kept as research; demo-studio kept as a needed
+  # marketing capability but built by integration, not a from-scratch recorder.
   - repo: core/agent-federation
-    tier: archive
+    tier: experimental
     moat: false
-    purpose: Cross-operator federation research; must not block centralized fabric. Park.
+    review_by: 2026-09-01
+    purpose: Cross-operator federation research (kept; revisit by review_by — must not block central fabric).
     owner: TBD
   - repo: tools/demo-studio
-    tier: archive
+    tier: integrate
     moat: false
+    integrates: Screen Studio driven via computer-use (keep AI orchestration; retire the from-scratch recorder)
     competes_with: Screen Studio, Camtasia
-    purpose: AI demo-video recorder; out of governance scope. Use a 3rd-party tool.
+    purpose: AI-created demo videos for GAL marketing (CLI/dashboard product is hard to demo).
     owner: TBD
   - repo: web/gal-app
-    tier: archive
+    tier: experimental
     moat: false
-    competes_with: Warp, iTerm
-    purpose: Warp-fork terminal client; commodity UX, no governance value.
+    review_by: 2026-09-01
+    purpose: Warp-fork terminal research (kept; revisit by review_by).
     owner: TBD


### PR DESCRIPTION
Per owner decision, none of the 3 audit 'archive' repos get archived:
- `tools/demo-studio` → **integrate** (Screen Studio via computer-use — keep the marketing-demo capability, retire the from-scratch recorder)
- `web/gal-app` (Warp fork) → **experimental** (research)
- `core/agent-federation` → **experimental** (research)

New tally: 15 core · 10 integrate · 6 experimental · 0 archive. Refs #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)