### PR TITLE
[skip ci] gov: relocate governance source-of-truth into the gal-run hub

### DIFF
--- a/governance/delegation.yaml
+++ b/governance/delegation.yaml
@@ -1,0 +1,89 @@
+# =============================================================================
+# DELEGATION MANDATE — how the enterprise OWNER delegates authority to the agent org.
+#
+# Shay is the enterprise OWNER, not the operator-of-last-resort. He sets the mandate +
+# risk limits ONCE, appoints/replaces the board, and READS the board's report. He does NOT
+# approve operations or most executive decisions — the agent org (board + C-suite officers)
+# decides within the limits below. Escalation flows agent → officer → board → owner; only
+# the bright-line `owner_reserved` set ever reaches the owner.
+#
+# SAFE BY DEFAULT: while `status: proposed`, this mandate is INERT — every decision still
+# routes to the owner (today's behavior). The OWNER flipping `status: granted` (his single
+# act) is what activates delegation. Enforced by agent_toolkit/authority.py (default-deny:
+# anything not explicitly delegated, or any owner-reserved flag, escalates to the owner).
+#
+# apiVersion: gal/v1 · kind: DelegationMandate · companion to capabilities.yaml (what each
+# agent may DO) — this is who may DECIDE what, and up to what limit.
+# =============================================================================
+apiVersion: gal/v1
+kind: DelegationMandate
+status: granted                  # GRANTED by the owner (Shay) on 2026-06-06, by direct instruction.
+owner: shay
+granted_by: shay                 # status==granted AND granted_by==owner → the router is now LIVE:
+                                 # officers decide within their limits; the bright line still → owner.
+                                 # (A stray status flip without this signature would stay inert.)
+granted_on: "2026-06-06"
+# NOTE: editing THIS FILE is `change_mandate` — owner-reserved. It must not be merged by an agent
+# officer; a diff under docs/governance/ routes to the owner (authority.constitution_paths()).
+
+# ---- The owner's mandate: the risk envelope the whole org operates within. Owner sets these.
+# (Starting proposals — conservative. Adjust the numbers; they are the owner's risk appetite.)
+mandate:
+  weekly_token_budget: 5540000           # the fleet salary cap (already enforced by the CFO)
+  max_officer_spend_usd: 0               # ZERO — no spend is delegated yet (owner set 2026-06-06).
+  max_board_spend_usd: 0                 # ZERO — EVERY spend authorization → owner until agents earn
+                                         # it per the trust ladder. Agents may still PROPOSE spend.
+                                         # (Raising these is a change_mandate — owner-reserved.)
+  values:                                # inviolable — officers decide WITHIN these
+    - revenue_first
+    - safety_gates_inviolable            # the HARD GATES never auto-fire (see owner_reserved)
+    - never_mix_human_and_agent_identity # capabilities.yaml Rule #1
+    - human_in_loop_on_outward_actions   # the HITL list (hitl.py)
+    - default_deny_escalates_up          # unknown/over-limit → up the chain, never auto-approve
+
+# ---- Decision lanes: who DECIDES what, within what limit, escalating to whom.
+#      `decider` is an EXISTING roster officer (an agent). `*` = role to staff via HR.
+authorities:
+  spend:
+    decider: cfo
+    limit: "amount_usd <= mandate.max_officer_spend_usd"
+    escalates_to: [board, owner]
+  set_budget:
+    decider: board
+    limit: "within mandate.weekly_token_budget and <= max_board_spend_usd"
+    escalates_to: [owner]
+  hire_fire:
+    decider: hr_ops_manager
+    limit: "within weekly budget AND passes the scorecard (firing_criteria)"
+    escalates_to: [board, owner]
+  merge_to_main:
+    decider: cto
+    limit: "PR passes the capability gate + tests AND is docs/schema/test-only class — EXCLUDING
+            docs/governance/** (the constitution = change_mandate, owner-reserved)"
+    escalates_to: [owner]
+  deploy_prod:
+    decider: cto
+    limit: "staging-verified, non-breaking, and NOT billing/security/paying-customer surface"
+    escalates_to: [board, owner]
+  outward_message:
+    decider: ceo
+    limit: "routine, non-binding, not to a paying customer"
+    escalates_to: [owner]
+  oss_contribution:
+    decider: cto
+    limit: "non-binding contribution to an approved repo; reviewed"
+    escalates_to: [owner]
+  go_live:
+    decider: board
+    limit: "agent passed probation (2 clean reviews) per the trust ladder"
+    escalates_to: [owner]
+
+# ---- The bright line: ALWAYS the owner. Never delegable to any agent, ever.
+#      (Also force-detected by flags in authority.py, so a mislabeled `kind` can't slip past.)
+owner_reserved:
+  - change_mandate                 # this file / the values / the limits — the constitution
+  - entity_or_captable             # equity, incorporation, binding major contracts
+  - bet_the_company_spend          # any single spend above max_board_spend_usd
+  - live_billing_or_pricing        # real money / paying customers (standing HARD GATE)
+  - security_rules_first_deploy    # the credentialed prod-replay IDOR sign-off (HARD GATE)
+  - appoint_or_replace_board       # who governs — the owner's call alone

--- a/governance/gal-governance-everywhere.md
+++ b/governance/gal-governance-everywhere.md
@@ -1,0 +1,201 @@
+# GAL Governance Everywhere — architecture + open-core strategy
+
+**Thesis:** one governance control plane (GAL) governs **every** agent runtime — OpenClaw,
+Hermes, Claude Code, Codex, OpenShell, the LangGraph/LangSmith fleet, and gal-model — for
+**people and agents alike**, with **human-in-the-loop on everything irreversible or
+outward-facing**, while open-sourcing only the thin integration glue and keeping the
+business logic closed.
+
+This is not a new strategy — it is the **execution** of GAL's existing, CI-enforced
+`cli/gal/governance/DEFINITION-OF-MOAT.md`. Drafted 2026-06-06. Builds on
+[the charter](gal-run-governance-charter.md) + [the mixing audit](identity-mixing-audit-2026-06-06.md)
++ the now-enforced [capability gate](capabilities.yaml). Eventual home: `gal-run/cli/gal/governance/`.
+
+---
+
+## 1. The architecture: PEP / PDP (this is what makes "everywhere" + "open-core" the same decision)
+
+Standard policy-enforcement split, mapped onto real `gal` primitives the recon confirmed exist:
+
+```
+   ANY runtime (OpenClaw · Hermes · Claude Code · Codex · OpenShell · LangGraph fleet · gal-model)
+        │  before a consequential action, the runtime asks:  "may this agent do this?"
+        ▼
+   ┌─────────────────────────────┐        thin, OPEN-SOURCE adapter per runtime.
+   │  PEP — Policy Enforcement    │        Does nothing but: call the PDP, emit an audit
+   │  Point  (the only OSS part)  │        event, and INTERRUPT (wait for a human) when told.
+   └──────────────┬──────────────┘        Exposes ZERO business logic.
+                  │  POST /enforcement/check  {agent, capability, scope, action}
+                  ▼
+   ┌─────────────────────────────────────────────────────────────┐   PROPRIETARY / cloud.
+   │  PDP — Policy Decision Point   (the moat, stays closed)       │   The value lives here.
+   │  governance-svc  →  {allowed | audit | human_required, reason}│
+   │   • policies (gal policy / governance-svc, Firestore)         │
+   │   • CapabilityManifest (who may do what — the gate we built)  │
+   │   • Agent Card contracts (gal-agents: identity/scope/auth)    │
+   │   • gal-model (learned governance advisory)  ← moat, esp.     │
+   │   • audit log (telemetry-svc governance_verdicts, append-only)│
+   └─────────────────────────────────────────────────────────────┘
+```
+
+- **PEP** = a tiny client embedded in (or wrapping) each runtime. "Ask, audit, and interrupt
+  if told." Open-sourcing it is pure adoption upside and leaks nothing.
+- **PDP** = `governance-svc`'s `/enforcement/check` returning `{allowed, action: allowed|denied|audit, reason}`
+  (already implemented), backed by policies + the CapabilityManifest + Agent Cards + gal-model + audit.
+  This is the moat. Cloud-served at `api.gal.run` behind the gateway JWT.
+
+Same decision, both goals: **the PEP is the "everywhere" surface AND the only thing we open-source.**
+
+---
+
+## 2. The open-core line — already your policy (`DEFINITION-OF-MOAT.md`), now applied
+
+| | **Open-source (commodity glue — adoption)** | **Proprietary (the moat — closed/cloud)** |
+|---|---|---|
+| What | per-runtime **PEP adapters** + the **wire protocol** (`/enforcement/check` request/response) + a thin **SDK** | the **PDP**: governance-svc engine, policies, **CapabilityManifest** logic, **Agent Card contracts** schemas-as-served, **gal-model**, the audit/compliance store, the propose→approve rails |
+| Moat-doc category | "coding agents / shells / automation = INTEGRATE" (commodity) | "policy+enforcement · governance contracts · cross-runtime capture+audit · governance decisioning (gal-model)" = BUILD |
+| Why OSS / why closed | exposes no logic; every runtime adopts for free → distribution (the Claude-Code-ecosystem PLG wedge) | the decisioning, the normalized cross-runtime capture, the contracts, and gal-model are what nobody else builds — enterprises pay for this |
+
+This is exactly *"as little open source as possible, still get the OSS benefit, don't expose
+business logic."* It is **already CI-enforced** by `charters.py` (a `tier: core` repo must be
+`moat: true`; a commodity rebuild is a drift violation). We are not redrawing the line — we
+are shipping the adapters on the OSS side of a line that already exists.
+
+> **Founder decision to confirm:** the line above (thin PEP + protocol OSS; engine + contracts
+> + gal-model closed). My recommendation is to ratify it as-is — it matches your moat doc.
+
+---
+
+## 3. Governance everywhere — one PEP per runtime
+
+Every runtime integrates the **same** way: a thin PEP that (a) calls `/enforcement/check`
+before a consequential action, (b) emits an audit event, (c) **interrupts for a human** when
+the PDP says `human_required`. Only the *embedding mechanism* differs per runtime.
+
+| Runtime | PEP embedding mechanism | Notes |
+|---|---|---|
+| **LangGraph/LangSmith fleet** (our 28 agents) | a pre-tool node calling `/enforcement/check`; **`interrupt()`** on `human_required` | native HITL; checkpointer already configured. The seed — built first. |
+| **Claude Code** | the existing **GAL hooks** (`gal hooks`/`gal enforce` install git + tool hooks) — "cross-runtime capture" is already moat | commodity runtime, governed by our hook. |
+| **Codex** | same hook/shim pattern (GAL already treats Codex as INTEGRATE) | thin adapter. |
+| **OpenClaw** | a PEP in the OpenClaw tool-dispatch path; today it's our Slack delivery identity too | already in the fleet; wrap its outbound. |
+| **Hermes** | PEP wrapping its tool/runtime boundary | thin adapter. |
+| **OpenShell** | PEP at the shell-exec boundary (a command is an action to check) | highest-risk surface → most actions `human_required`. |
+| **gal-model** | governed **as a runtime** (it holds capability grants + is audited) — boundary only | the model *itself* is proprietary PDP brain, built **outside Claude Code** (see §6). |
+
+The adapters are small and uniform precisely because the PDP holds all the logic — which is
+what lets us be "everywhere" without forking the moat into N runtimes.
+
+---
+
+## 4. Human-in-the-loop — the safety spine (your fear, made structural)
+
+An agent opening an OSS pull request, or messaging a real person, is **irreversible and
+outward-facing**. Those never fire on an agent's own authority. HITL is the bridge from
+today's "report-only, never acts" to *safe* autonomy.
+
+**Three tiers, by consequence (reversibility × touches-people-or-the-world):**
+
+1. **Autonomous** — safe, reversible, internal (reads, analysis, internal digests, private drafts). No human. *This is what lets the company run without you.*
+2. **Human-in-the-loop** — outward/irreversible: **OSS contributions (any push/PR/comment to a public or external repo), any message to a person (email, Slack DM, external reply), publishing/posting.** The agent does the work, then **stops** and surfaces the exact artifact (the diff, the message text, the recipient) for **approve / edit / reject**. **Fail-closed** — no approval, no action.
+3. **Founder-gated (HARD GATE)** — capital, legal, prod deploy, billing, security-rules, paying customers. Yours, above normal HITL.
+
+**Mechanism:** `/enforcement/check` returns `audit` or **`human_required`**; the PEP enforces
+it. On the LangGraph fleet that's **`interrupt()`** (the LangSmith HITL you meant — native,
+checkpointer present); each other runtime has its equivalent pause. Approvals **queue** (they
+never block on *you* specifically — any authorized human clears routine ones) and surface in
+the LangGraph inbox **+ mirrored to Slack** for one-tap approval. Every interrupt + decision
+(who/what/when) → the append-only audit log (charter control #4). **Which capabilities are
+`human_required` is a PDP policy** — one auditable list, changed only via `gal propose`→`approve`
+(an agent can't widen its own latitude).
+
+**The starting "always needs a human" list (for you to ratify or tighten):**
+OSS/external-repo contributions · any message to a human · publishing/posting · account or
+permission changes · anything touching paying customers · spend that moves real money. *(The
+capability manifest's verb allow-list already blocks procurement/execute outright; this layer
+gates the *outward* `write`/`post`/`propose` verbs that reach the world.)*
+
+---
+
+## 5. Agents as members — on Scheduler **and** gal-run, alongside people
+
+A person and an agent are both **members**; the agent is a governed NHI, not a second-class
+script. The records already exist in GAL — we unify them:
+
+| Layer | For a person | For an agent (NHI) | Status |
+|---|---|---|---|
+| **Identity / contract** | human account (owner/teammate) | **Agent Card** (gal-agents: identity, scope, auth, governance profile) | exists |
+| **What it may do** | role/permissions | **CapabilityManifest grant** (the gate we built — agent/capability/scope/why/granted_by) | built (CI-enforced) |
+| **Workforce / schedule** | employee profile + shifts (Scheduler) | **roster.yaml employee row** + shift trigger (Scheduler = workforce layer) | exists (roster gate) |
+| **Join flow** | invite | **`gal join` / `gal fleet`** → Agent Card + manifest grant + roster row + HR hire | rails exist |
+| **Governed by** | the PDP | the PDP (same `/enforcement/check`) | exists |
+
+So "add an agent" = the same member-onboarding flow as a person: an Agent Card (gal-run), a
+capability grant (governed), a Scheduler employee profile + shift (workforce), an HR hire
+(approval-gated). People and agents, one membership model, one control plane.
+
+---
+
+## 6. The gal-model boundary (honest + strategy-aligned)
+
+Your moat doc lists **gal-model as moat** ("learned governance advisory") — i.e. it belongs in
+the **proprietary PDP core**, exactly where open-core wants it. That aligns with a hard limit
+on my side: **I cannot develop/train/eval/serve gal-model via Claude Code** (Anthropic terms +
+workspace AGENTS.md). The split:
+
+- ✅ **I can govern the boundary** — treat gal-model as a governed runtime (it holds capability
+  grants, its advisory verdicts are audited), define the PDP interface that *calls* it, and
+  wire HITL/audit around it. This is application/contract code, not ML.
+- ❌ **I cannot build the model** — its training/eval/serving happens **outside Claude Code**.
+
+Net: gal-model stays a closed black box in the moat (where your strategy wants it); I integrate
+governance *around* it, not the model itself.
+
+---
+
+## 7. Build plan (HARD-GATE aware; gal-model untouched)
+
+> **Status 2026-06-06 — Phase 1 + 2 BUILT (local feature branches, nothing pushed to gal-run / deployed):**
+> - **Phase 1 ✅** `gal capability validate` — a faithful Rust port of the Python gate, in
+>   `gal-cli-rs` (branch `feat/capability-manifest-gate`); 19 Rust tests + the adversary kill-shot;
+>   **verified equivalent to the Python gate on the real 28-graph fleet** (same exit 0, same warnings).
+>   `gal capability propose` rides the existing `create_proposal` rails. Schema
+>   `cli/gal/schemas/capability-manifest.schema.json` (branch `feat/capability-manifest-schema`)
+>   validates the real manifest. `capabilities.yaml` gained the `apiVersion: gal/v1` / `kind:
+>   CapabilityManifest` header + canonical-bool normalization. **GAL is now the enforcing authority.**
+> - **Phase 2 ✅** `agent_toolkit/hitl.py` — the HITL gate: pure `human_required()` (the ratified
+>   policy) + `human_gate()` that records-but-never-blocks on probation and `interrupt()`s when live
+>   (fail-closed; langgraph lazy-imported). 15 tests. Report-only by default — nothing acts yet.
+> - **Held for founder review before any push to gal-run / merge / deploy / go-live.**
+
+**Phase 1 — the seed (buildable now, crosses NO gate; feature branches/worktrees only):**
+Re-home the capability gate onto GAL (per the recon design):
+- `cli/gal/schemas/capability-manifest.schema.json` (`apiVersion: gal/v1`, `kind: CapabilityManifest`).
+- `gal capability validate` — a faithful **Rust port** of `check_capability_coverage.py::validate()`
+  (deterministic rule-checking, NOT ML) in `gal-cli-rs`, carrying the 36 unit tests; wire it into `gal check`.
+- Swap the qa-agent-platform CI step from the Python gate to `gal check validate --capability-manifest`.
+- `capabilities.yaml` gains the `apiVersion`/`kind` header; charter + audit relocate to `cli/gal/governance/`.
+- The propose→approve→approved-config→audit rails already exist — no new approval machinery.
+
+**Phase 2 — HITL spine (buildable now, code only):** a reusable PEP node for the LangGraph
+fleet that calls `/enforcement/check` and `interrupt()`s on `human_required`; the `human_required`
+policy list; Slack approval mirror. Report-only/dry by default.
+
+**Phase 3 — the universal PEP + protocol (the OSS surface):** factor the PEP into a thin
+open-sourceable adapter + wire protocol + SDK; one adapter each for Claude Code / Codex /
+OpenClaw / Hermes / OpenShell. Engine stays closed.
+
+**Phase 4 — agents-as-members:** unify Agent Card + capability grant + roster row + Scheduler
+profile behind one `gal join`/HR flow.
+
+**GATED throughout (founder / not me):** pushing to gal-run or Scheduler-Systems orgs; any
+`main` merge; deploying governance-svc; the first `gal approve set` blessing a manifest that
+touches identities/funding; ring-fencing the funding pool; turning any agent from report-only
+to live. **gal-model model-dev stays outside Claude Code.**
+
+---
+
+## Founder decisions queued
+1. **Confirm the open-core line** (§2) — recommend ratify as-is (it's your moat doc).
+2. **Ratify the HITL "always needs a human" list** (§4) — tighten if you want it stricter.
+3. **Approve building Phase 1 + 2 now** (no gate crossed — feature branches, no push/deploy).
+4. Standing gates unchanged: push to gal-run, prod deploy, billing/ring-fence, going live.

--- a/governance/gal-run-governance-charter.md
+++ b/governance/gal-run-governance-charter.md
@@ -1,0 +1,141 @@
+# GAL-Run Governance Charter
+
+**What GAL-run is for:** to control *which agent can access what, why* — so a human stays in
+control of everything and can never be outsmarted by agents. Not "smarter agents" — **provable
+human control**: least-privilege, justified, auditable, revocable, killable, with humans in a tier
+agents cannot climb into.
+
+*(Canonical home: the gal-run governance repo. Drafted 2026-06-06 alongside the fleet it first
+governs. Enforcement lives where the agents run — e.g. `qa-agent-platform/roster.yaml` +
+`scripts/check_roster_coverage.py`.)*
+
+---
+
+## Rule #1 (cardinal) — Human and agent identities NEVER mix
+
+Every identity is **either** a human **or** an agent. One credential lives in exactly one tier,
+and every action is attributable to exactly one tier. The only legal connection between tiers is
+**issuance** (a human creates/revokes an agent credential) — never a shared login, never
+"borrowing a session."
+
+| | **Human identity** | **Agent identity (NHI)** |
+|---|---|---|
+| Belongs to | a *person* | a *software process* |
+| Auth by | password+2FA / passkey (only the person has it) | a scoped credential *issued by a human* (service-account key, API sub-key, app/bot token, short-lived token) |
+| Carries | ownership, billing/payment, approval, grant/revoke, legal accountability | **only the capabilities granted — nothing more** |
+| Can buy / grant / own / approve? | yes | **never** |
+| Cost | paid seats | free / cheap |
+| Lifecycle | the person's | created, scoped, audited, **revoked at will** by a human |
+| Blast radius | the person's full authority | confined to itself |
+
+- A human identity **OWNS and ISSUES** an agent identity (your GitHub login owns the GitHub *App*).
+- **Accountability always chains up**: every agent action → (1) the agent identity that did it +
+  (2) the human who owns/granted it. No unowned agents.
+- The **founder's human identity is the top of the tree and is never given to an agent.**
+
+**Mixing — all banned:** an agent (or a builder/tool session) acting through a human's session or
+credentials; a shared account a human and agent both log into; an agent posting *as* a human;
+agent credentials stored inside/derivable from a human credential. *(This binds the builder too:
+use agent/API identities, never the founder's sessions.)*
+
+---
+
+## The primitive — a capability grant
+
+Everything is one of these, declared and enforced:
+> `{ agent, capability, scope, WHY (justification), granted_by (human), expires, revocable }`
+
+Default-deny + least-privilege: an agent holds *exactly* its grants. It cannot acquire a new
+credential, widen a scope, self-grant, or escalate at runtime. New capability = explicit, justified,
+human-approved, expiring, revocable.
+
+---
+
+## The five structural controls that make "never outsmarted" true
+
+Control must be **structural, not behavioral** (an instruction an agent could ignore won't do):
+
+1. **Trust-domain separation** — the human/control-plane lives where agents cannot reach (separate
+   creds, separate infra). Agents can't read master keys, edit policy, or approve their own grants.
+2. **Capability confinement** — the agent's runtime contains exactly its grants; no self-grant, no
+   escalation. (Why an inference key can't buy tokens: the *capability* isn't there.)
+3. **Mediated escalation** — anything beyond a grant goes through a human-approval gate the agent
+   can't bypass. It *proposes*; it never *approves* — for itself or another agent.
+4. **Tamper-evident audit** — every capability use logged to an append-only store agents can't alter.
+   The human always has ground truth, not the agents' word.
+5. **Default-deny + universal kill switch** — least-privilege by default; the human halts the whole
+   fleet instantly from outside the agents' reach (`AGENTS_DISABLED`).
+
+---
+
+## Money — spend-only, never procure; ring-fenced funding
+
+- Agents get **spend-only** capabilities (an inference key spends a balance) — **never** procurement,
+  billing, payment, or capital. Buying capacity / changing a plan / moving money is a **HARD GATE**
+  (founder-only). An agent may *propose* "we're low, top up" — it never *does* it.
+- **A spend-only capability is only spend-only if the funding can't auto-procure.** Govern *both*
+  ends. The manifest records per provider:
+  > `{ provider, funding_instrument, auto_recharge: off, max_$_exposure, ring_fenced: yes }`
+- **Funding rules:** one **ring-fenced, hard-capped** instrument for the whole agent platform
+  (vendor/prepaid card with a fixed cap, **auto-recharge OFF**) — **separate from the founder's /
+  company's main card**. Per-agent budgets enforced internally (CFO + budget cap). Max real-money
+  blast radius = that one capped pool, never the founder's card.
+- **Two budget layers, don't confuse them:** the **token salary cap** (`team_token_budget`, ~5.54M
+  tokens/wk ≈ ~$5–10/mo of model spend) bounds *model* tokens only. The *real* recurring money is
+  **managed-deployment compute (24/7) + provider billing** — bound those at the funding instrument.
+
+---
+
+## Identity ≠ seat (cost reconciliation)
+
+"Every agent has its own account" = its own **isolated machine identity**, NOT a paid human seat and
+NOT a shared founder login. Isolation without per-seat cost: GitHub App / installation token, Google
+service account / free Cloud Identity, model inference sub-key, Slack App bot token. Per-service map:
+
+| Service | Human identity (founder, top tier) | Agent identity (scoped) | Money |
+|---|---|---|---|
+| GitHub | login (owns org + billing) | GitHub **App** / installation token | — |
+| Google | Workspace account | **service account** / free Cloud Identity | — |
+| Models (DeepSeek…) | account login (owns the card) | **inference sub-key** (spend-only) | ring-fenced pool, **not founder card** |
+| Slack | membership | Slack **App** bot token | — |
+| LangSmith | account (owns deploy + billing) | deployment + scoped key | flat 24/7 compute = real cost |
+
+---
+
+## How the fleet maps onto this today (first governed manifest)
+
+- **Identity model:** agents run as `app[bot]`/service creds (GitHub App, OpenClaw Slack bot, ASC API
+  key) — good. **Gap:** the *builder* (Claude) used the founder's logged-in sessions this session
+  (Slack/RC/App Store/LangSmith/GCP) — a Rule-#1 violation; see the mixing audit + replace with agent
+  identities/APIs.
+- **Capability/HR:** `roster.yaml` is the first capability/employment registry (role, grade, salary,
+  scorecard, `hire: pending_hr_approval`); `check_roster_coverage.py` is a hard gate (no deploy without
+  a row). HR hire = approval-gated to the founder.
+- **Capability manifest (NEW, enforced):** `docs/governance/capabilities.yaml` declares every deployed
+  agent's agent-tier identities + grants (capability/scope/why/granted_by) + ring-fenced funding.
+  `scripts/check_capability_coverage.py` is a CI gate that FAILS the build on a human-identity reference
+  (Rule #1), any `can_buy`/procurement verb (spend-only), a missing grant (default-deny), or an
+  auto-recharging non-ring-fenced pool. **The two cardinal rules are now machine-checked, not just
+  written** (19 unit tests; green on all 28 graphs).
+- **Kill switch / budget:** `AGENTS_DISABLED` + `per_run_token_ceiling: 50000` + per-agent salary.
+  **To build:** fleet-burn ≥ cap → flips `AGENTS_DISABLED` (auto clock-out).
+- **Money:** verify/remove the card + auto-recharge on every provider (founder); move to one
+  ring-fenced capped instrument. **This is the top open governance gap.**
+
+---
+
+## Build backlog (turning this charter into enforced reality)
+
+1. ✅ **Capability manifest + CI gate** — `capabilities.yaml` + `check_capability_coverage.py` enforce
+   Rule #1 (tier separation, non-empty human set, human-issuance chain, human-only `granted_by` / no
+   self-grant), spend-only (allow-listed verbs + real-boolean `can_buy`), the `report_only` probation
+   posture, `revocable`, least-privilege scope, and coverage — at PR/CI time. Adversarially verified
+   (2026-06-06): a combined human-credential + auto-recharge + self-grant bypass that previously passed
+   is now caught with 18 distinct errors. **Still TODO:** push the SAME check to the *runtime boundary*
+   (an agent holds only its manifest grants at execution, not merely at CI); enforce an `expires`
+   lifecycle; and add an attested NHI catalog so a human credential can't be mislabeled `tier: agent`.
+2. **Budget-cap enforcement** — burn ≥ cap → `AGENTS_DISABLED`.
+3. **Ring-fence funding** (founder) + record max-$ exposure per provider.
+4. **Tamper-evident audit log** of every capability use (agents can't alter).
+5. **Close the mixing violations** (see the companion mixing audit) — agent identities replace human
+   sessions everywhere, starting with the builder's.

--- a/governance/identity-mixing-audit-2026-06-06.md
+++ b/governance/identity-mixing-audit-2026-06-06.md
@@ -1,0 +1,77 @@
+# Identity-Mixing Audit (2026-06-06)
+
+Companion to the GAL-Run Governance Charter. Rule #1 = **human and agent identities never mix.**
+This enumerates every place an agent OR a builder/tool currently acts through a *human* credential
+(a violation), and the agent identity that should replace it.
+
+Legend: **HUMAN** = a person's credential/session · **AGENT** = a scoped machine credential ·
+**MIX** = an agent/tool using a human credential (banned).
+
+## A. Builder (Claude / this session) — the live violations
+
+The biggest mixing this session was *me* operating through the founder's logged-in browser sessions
+instead of agent/API identities. Each must be replaced with an agent credential.
+
+| Action I took | Credential used | Verdict | Fix (agent identity) |
+|---|---|---|---|
+| Invited bot, navigated Slack channels | founder's **Slack web session** | **MIX** | Slack Admin/API with a scoped token; or founder issues a one-time invite, agents post via the bot (already AGENT) |
+| Read RevenueCat dashboard | founder's **RC login** | **MIX** | `revenuecat.py` + RC **API key** (AGENT) — the API path already exists; stop using the console |
+| Navigated App Store Connect | founder's **ASC session** (login failed) | **MIX (attempted)** | `store_ops` **ASC API key** (AGENT) — already built; never the console |
+| Opened LangSmith deployment settings | founder's **LangSmith login** | **MIX** | deploy-scoped **service key** `lsv2_sk_…` (AGENT) — already used for deploys; stop using the UI |
+| Read GCP Secret Manager | **github-action service account** | borderline-OK | a service identity, not the founder's login — but scope it to least-privilege (see C) |
+
+**Principle reaffirmed:** the builder uses agent/API identities. Where a console has no API and sits
+behind the founder's 2FA, that's a *gap to close with an agent credential* — not a license to log in
+as the founder.
+
+## B. Fleet agent credentials (these are correctly AGENT, with notes)
+
+| Credential | Tier | Note / risk |
+|---|---|---|
+| GitHub **App** (`FLEET_APP_ID`) | AGENT ✓ | permission-scoped, no billing access. Good. |
+| OpenClaw **Slack bot token** (`xoxb-…`) | AGENT ✓ | but **shared** by all agents (not per-agent isolated) and stored **plaintext** in `~/.openclaw/openclaw.json` on the founder's Mac (alongside app + gateway tokens) → **storage hygiene + isolation gap**. |
+| ASC API key / Play SA / model keys | AGENT ✓ | service creds, in GCP SM + deployment env. Good. |
+| DeepSeek / Gemini inference keys | AGENT ✓ | **spend-only** — cannot buy (provided funding can't auto-recharge: see C). |
+| LangSmith deploy key `lsv2_sk_…` | AGENT ✓ | service/deploy key — confirm it is NOT the founder's personal key. |
+
+## C. The money / funding audit (the top open gap)
+
+A spend-only key is only spend-only if the funding can't auto-procure. **For every provider the fleet
+can spend on, verify (founder action — billing is a HARD GATE):**
+
+| Provider | Spend by | **Verify** |
+|---|---|---|
+| DeepSeek | inference key | card on file? auto-recharge OFF? hard cap? |
+| Google / Gemini (GCP) | API key / SA | GCP billing account = founder card? budget alert + cap? |
+| Anthropic | API key | postpaid w/ card? spend limit? |
+| OpenAI | API key | card + auto-recharge? hard cap? |
+| LangSmith / LangGraph | account | plan + 24/7 compute on founder card? |
+| Vercel / Firebase | account | plan on founder card? |
+| RevenueCat | API key | (read-mostly) plan billing? |
+
+**Target:** one **ring-fenced, hard-capped** funding instrument for the whole agent platform
+(auto-recharge OFF), **separate from the founder's/company main card**. Max real-money blast radius =
+that capped pool. *Until verified, exposure is unbounded via auto-billing — this outranks any single
+agent's permissions.*
+
+## D. Remediation backlog (close the mixes)
+
+1. **Stop builder-via-founder-session.** Route Slack/RC/LangSmith ops through agent APIs/keys (stores
+   already done via `store_ops`). For console-only/2FA actions, mint an agent credential, don't log in
+   as the founder.
+2. **Ring-fence funding** (founder): verify/remove cards + auto-recharge per provider (table C); move
+   to one capped instrument; record `max_$_exposure` per provider in the capability manifest.
+3. **Secret hygiene:** move the OpenClaw plaintext tokens out of `~/.openclaw/openclaw.json` into a
+   secret store; rotate; consider per-agent/per-department bot identities for isolation + attribution.
+4. **Scope the CI/SM service account** to least-privilege (only the secrets it needs).
+5. **Confirm** the LangSmith deploy key + any "service" key is not a founder personal credential.
+
+Every item above is an instance of Rule #1 or the funding rule. Closing them turns "we don't mix
+identities" from an intention into an audited, enforced boundary.
+
+**Now enforced (deployed agents):** `docs/governance/capabilities.yaml` +
+`scripts/check_capability_coverage.py` (a CI gate) machine-check that no *deployed* agent references a
+human-tier identity, none can procure (`can_buy`/procurement verbs), and the funding pool can't
+auto-recharge without a ring-fence. That covers section B (the fleet). Section A (the *builder* using
+founder sessions) and section C (funding provisioning) remain discipline + founder actions — the gate
+governs agents at CI, not the human at the console.

--- a/governance/owner-operating-model.md
+++ b/governance/owner-operating-model.md
@@ -1,0 +1,72 @@
+# Owner Operating Model — how Shay owns the company without running it
+
+**Shay is the enterprise OWNER, not the operator-of-last-resort.** This is the design that takes
+him out of the operational loop: the agent org (board + C-suite officers) decides within an
+owner-set mandate; escalation flows agent → officer → board → owner; only a small, bright-line set
+ever reaches him. Built 2026-06-06. Enforced by `agent_toolkit/authority.py` over
+[`delegation.yaml`](delegation.yaml); pairs with [`capabilities.yaml`](capabilities.yaml) (what each
+agent may DO) and [`hitl.py`](../../agent_toolkit/hitl.py) (the pause that waits for the approver this
+router names).
+
+## The owner's entire footprint (this is all you do)
+1. **Set the mandate once** — the risk envelope: spend limits, the weekly budget, the values
+   (`delegation.yaml#mandate`). Amend rarely.
+2. **Appoint / replace the board** — who governs. The board (`board_chair`, `audit_risk_director`,
+   `growth_director`) produces THE investor update to you.
+3. **Read the board's report** — you *receive* it; you don't approve operations.
+4. **Hold the bright line** — the few owner-reserved decisions below. Agent-prepared, batched, one-tap.
+
+Everything else is decided by the org you own — **not by you.**
+
+## Who decides what (the delegation, live once you grant it)
+| Decision | Decider (an agent officer) | Owner only when… |
+|---|---|---|
+| Spend | **CFO** (≤ officer limit) → board (≤ board limit) | above the board limit (bet-the-company). **Caps are $0/$0 as of 2026-06-06 — no spend is delegated yet; every spend authorization comes to you. Agents may PROPOSE spend; caps rise per-lane as agents earn tenure.** |
+| Budget | **Board** (within your weekly cap) | changing the cap |
+| Hire / fire | **HR** (within budget + scorecard) | changing the comp/headcount mandate |
+| Merge to `main` | **CTO** (passes gate + tests, docs/schema/test class) | — |
+| Deploy to prod | **CTO** (staging-verified, non-breaking, non-billing/security) | billing/security/paying-customer surface |
+| Outward message / OSS contribution | **CEO / CTO** (routine, non-binding) | binding or to a paying customer |
+| Go live (report-only → live) | **Board** (agent passed probation) | the initial "fleet goes live" |
+
+## The bright line — always you, never delegable (`owner_reserved`)
+Change the mandate · entity/cap-table/binding major contracts · bet-the-company spend · live
+billing or pricing · the first security-rules (IDOR) prod deploy · appoint/replace the board.
+These are force-detected by flags too, so a decision mislabeled as something smaller **cannot**
+slip past — it still reaches you.
+
+## The single act only you can do
+The mandate ships **`status: proposed`** — *inert*. Every decision still routes to you (today's
+behaviour) until **you flip `status: granted`**. That one act is the owner exercising ownership:
+delegating your authority to the org you own. It is one-time; after it, the lanes above run
+themselves and you drop out of them. (The standing HARD GATES — live billing, prod, security,
+paying customers — stay near you because they're in `owner_reserved`; delegating *those* is a
+separate, deliberate owner act per lane, never automatic.)
+
+## When the loop ends
+- **Now → weeks:** the operational drip (approve this PR, ratify that list) collapses — each lane
+  gets an officer; you grant the mandate once.
+- **Ongoing:** the trust ladder (`roster.yaml`: probation → tenure after clean reviews) shrinks the
+  gated set as agents earn it; officers' limits rise on your sign-off.
+- **End state:** your time on operations → near-zero. You own the company, set its mandate, appoint
+  its board, read its reports, and hold a handful of bright-line levers. That is ownership — not a
+  loop to escape, but the small, deliberate footprint of an owner.
+
+> Safety note: nothing here removes a HARD GATE or activates delegation on its own. The mandate is
+> inert until you grant it; owner-reserved is never delegable; default-deny escalates anything
+> unrecognized up to you. The machine is built; the authority is yours to grant.
+
+## How the mandate itself is protected (red-teamed 2026-06-06)
+An adversarial pass found — and we then closed — every way an agent could route a money/billing
+decision to itself instead of you: non-finite/negative spend amounts, falsy "billing" flags, and the
+inert-mode leak all now fail closed to the owner (regression-tested). Two further protections:
+- **Owner signature:** the router treats the mandate as live only when `status: granted` **and**
+  `granted_by: shay` — a stray `status` flip alone stays inert.
+- **The constitution can't be edited by an agent:** editing `docs/governance/**` is `change_mandate`
+  (owner-reserved), explicitly carved out of the CTO's merge lane; CI pins the spend ceilings and the
+  full bright-line set, so raising a cap or dropping a reserved item turns the build **red**.
+- **Still owner/repo-admin to do (gated):** add `CODEOWNERS` (`/docs/governance/ @<owner>`) + branch
+  protection requiring your review on those paths — belt-and-suspenders on top of the CI pins above.
+- **Residual trust:** the router trusts the action's `kind`/flags, so high-risk flags
+  (`touches_billing`, …) must be stamped by a trusted tool/classifier, not self-asserted by the
+  deciding agent. That stamping is the one assumption the whole model rests on.

--- a/schemas/delegation-mandate.schema.json
+++ b/schemas/delegation-mandate.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Scheduler-Systems/gal-run/schemas/delegation-mandate.schema.json",
+  "title": "GAL Delegation Mandate",
+  "description": "The enterprise OWNER's delegation of authority to the agent org: who DECIDES what, within what limit, escalating to whom; the bright-line set reserved to the owner. Enforced by `gal delegation route`. The mandate is INERT (every decision → owner) until the owner sets status: granted AND granted_by == owner. Booleans MUST be canonical true/false.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "status", "owner", "authorities", "owner_reserved"],
+  "properties": {
+    "apiVersion": { "const": "gal/v1" },
+    "kind": { "const": "DelegationMandate" },
+    "status": { "enum": ["proposed", "granted"], "description": "Only the owner flips this to granted." },
+    "owner": { "type": "string", "minLength": 1 },
+    "granted_by": { "type": "string", "description": "Must equal `owner` for the mandate to be live (the router enforces this)." },
+    "granted_on": { "type": "string" },
+    "mandate": {
+      "type": "object",
+      "description": "The owner's risk envelope. Officers decide within these.",
+      "additionalProperties": false,
+      "properties": {
+        "weekly_token_budget": { "type": "integer", "minimum": 0 },
+        "max_officer_spend_usd": { "type": "number", "minimum": 0, "description": "An officer may authorize spend up to this; above → board → owner." },
+        "max_board_spend_usd": { "type": "number", "minimum": 0, "description": "The board may authorize up to this; above = bet-the-company = owner." },
+        "values": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "authorities": {
+      "type": "object",
+      "description": "Decision lanes. Each `decider` is an agent-officer (or the board).",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["decider", "escalates_to"],
+        "properties": {
+          "decider": { "type": "string", "minLength": 1 },
+          "limit": { "type": "string" },
+          "escalates_to": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+        }
+      }
+    },
+    "owner_reserved": {
+      "type": "array",
+      "description": "The bright line — always the owner, never delegable. Also force-detected by flags in the router.",
+      "items": { "type": "string" },
+      "minItems": 1
+    }
+  }
+}


### PR DESCRIPTION
Un-drifts the governance source-of-truth out of the Scheduler-Systems fleet repo (`agent-platform`) into GAL's governance hub (`cli/gal/governance/`), where the control plane belongs.

## Moves into the hub (canonical)
- The charter, identity-mixing-audit, the governance-everywhere design, and the owner-operating-model.
- **`delegation.yaml`** — the **enterprise owner mandate** (governs the whole company; it had no business in a QA-fleet repo).
- **`schemas/delegation-mandate.schema.json`** — its config-type contract; validated against the real granted mandate.

## Stays fleet-local (by owner decision)
- `capabilities.yaml` — the fleet's *own* instance (its 28 grants); declared by the fleet, validated/approved by GAL.

## Enforcement (already in GAL)
- `gal capability validate` (gal-cli-rs#11) + `gal delegation route` / `gal delegation hitl` (same PR) — the engine/PDP.

Companion to gal-cli-rs#11 (validator+engine) and gal/#416 (capability schema). Follow-ups: polish inline references (`check_capability_coverage.py` → the `gal` CLI) and remove the now-stale fleet-repo copies (deletion = owner approval). Merge remains owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)