### PR TITLE
Scrub internal codename leaks + dead links from public tree

### DIFF
--- a/apps/dashboard/src/components/sessions/QueueTabContent.tsx
+++ b/apps/dashboard/src/components/sessions/QueueTabContent.tsx
@@ -1602,7 +1602,7 @@ export function QueueTabContent() {
             action: 'auth_refresh',
             reason: 'Claude OAuth expired during queue canary',
             preventedByIssueNumber: 4554,
-            actorLogin: 'karabil',
+            actorLogin: 'test-user',
             createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
           },
         ],

--- a/apps/dashboard/src/lib/dashboard-startup.test.ts
+++ b/apps/dashboard/src/lib/dashboard-startup.test.ts
@@ -10,7 +10,7 @@ describe('dashboard startup recovery', () => {
     const result = await loadHomeGitHubBootstrap({
       getPersonalGitHubStatus: vi.fn().mockResolvedValue({
         connected: true,
-        username: 'karabil',
+        username: 'test-user',
       }),
       getGitHubAppStatus: vi.fn().mockRejectedValue(new Error('timeout')),
     })
@@ -18,7 +18,7 @@ describe('dashboard startup recovery', () => {
     expect(result).toEqual({
       githubStatus: {
         connected: true,
-        username: 'karabil',
+        username: 'test-user',
       },
       hasInstallations: false,
     })

--- a/services/NOTICE
+++ b/services/NOTICE
@@ -10,4 +10,4 @@ License at http://www.apache.org/licenses/LICENSE-2.0
 These are the open self-hostable services (the PDP, auth, gateway, MCP, RAG,
 sync client) of the gal governance kernel. The managed control plane (billing,
 cross-tenant aggregator, multi-tenant ops) is the separate, proprietary
-gal-cloud and is not covered by this license. See CARVE.md.
+gal-cloud and is not covered by this license.

--- a/services/gal-rag/TECH.md
+++ b/services/gal-rag/TECH.md
@@ -1,7 +1,7 @@
 # gal-rag — Technical Specification
 
 **Status:** Draft v0.1 (2026-06-02)
-**RFC:** [gal-run/go-services#33](https://github.com/gal-run/go-services/issues/33)
+**RFC:** internal design note
 **Owner:** gal-rag team
 **Related spec:** [`.tmp/gal-memory-routing-spec.md`](../../.tmp/gal-memory-routing-spec.md)
 
@@ -944,7 +944,7 @@ out in the same monorepo.
 
 ## 15. References
 
-- RFC: <https://github.com/gal-run/go-services/issues/33>
+- RFC: internal design note
 - Memory routing spec: `.tmp/gal-memory-routing-spec.md`
 - Embedding schema enum: `gal-run/web/gal-app/crates/warp_graphql_schema/api/schema.graphql`
 - Existing memory tools: `gal-run/mcp/gal-mcp/src/tools/memory-tools.ts`

--- a/services/gal-rag/test/integration/ingest_test.go
+++ b/services/gal-rag/test/integration/ingest_test.go
@@ -79,7 +79,7 @@ func TestJobLifecycle(t *testing.T) {
 	// Enqueue.
 	jobID, err := ingest.Enqueue(ctx, st, ingest.EnqueueRequest{
 		OrgID:      "test-org",
-		RepoScope:  "gal-run/go-services",
+		RepoScope:  "example-org/example-repo",
 		SourceKind: "memory_entry",
 		SourceType: "memory",
 		Content:    "hello world integration test",
@@ -130,7 +130,7 @@ func TestDLQPromotion(t *testing.T) {
 
 	jobID, err := ingest.Enqueue(ctx, st, ingest.EnqueueRequest{
 		OrgID:      "test-org",
-		RepoScope:  "gal-run/go-services",
+		RepoScope:  "example-org/example-repo",
 		SourceKind: "github_file",
 		SourceType: "go",
 		Content:    "package main",
@@ -177,7 +177,7 @@ func TestDeduplication(t *testing.T) {
 
 	req := ingest.EnqueueRequest{
 		OrgID:      "test-org",
-		RepoScope:  "gal-run/go-services",
+		RepoScope:  "example-org/example-repo",
 		SourceKind: "github_file",
 		SourceType: "go",
 		Content:    "package dedup",

--- a/services/gal-rag/test/integration/search_test.go
+++ b/services/gal-rag/test/integration/search_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	testOrg       = "test-org"
-	testRepoScope = "gal-run/go-services"
+	testRepoScope = "example-org/example-repo"
 	testColl      = "gal_rag_chunks"
 	voyageDim     = 512
 )

--- a/services/repo-svc/cmd/server/sync_pull.go
+++ b/services/repo-svc/cmd/server/sync_pull.go
@@ -26,7 +26,7 @@ import (
 // rules), repo-svc fetches it over HTTP, mirroring the existing gal-rag
 // integration. The data source is isolated in fetchApprovedConfig so a
 // reviewer can swap it (e.g. for a direct shared-store read) without changing
-// the handler logic. See gal-run/go-services#50.
+// the handler logic.
 //
 // Org is taken from the JWT context (auth.OrgID), not the request body — the
 // caller can only pull config for the org their token authorizes. Platform is

--- a/services/repo-svc/cmd/server/sync_pull_test.go
+++ b/services/repo-svc/cmd/server/sync_pull_test.go
@@ -56,7 +56,7 @@ func doSyncPull(svc *repoService, org, authz string) *httptest.ResponseRecorder 
 }
 
 func TestSyncPull_HappyPath(t *testing.T) {
-	body := `{"platform":"claude","hash":"abc","version":"3","approved_at":"2026-06-03","approved_by":"karabil"}`
+	body := `{"platform":"claude","hash":"abc","version":"3","approved_at":"2026-06-03","approved_by":"test-user"}`
 	svc, _ := newSyncPullTestService(t, http.StatusOK, body, "Bearer tok123")
 
 	rec := doSyncPull(svc, "ZenuxLabs", "Bearer tok123")


### PR DESCRIPTION
Genericizes internal-only references in the public tree (test fixtures, founder handle fixtures, a private-issue comment link, the NOTICE CARVE.md pointer, two dead RFC links). No production logic changed; the deeper TECH.md architecture-prose genericization is a follow-up.

Closes #426