### PR TITLE
docs: honest self-host story + kernel make lib target + status/support drift [ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,30 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-brightgreen" alt="License"></a>
 </p>
 
-# gal — open governance platform; kernel at head; self-host today
+# gal — open governance platform; kernel at head; build from source today
 
 gal governs AI agents from a small, auditable core. A pure-C **reference
 monitor** sits at the head of the repo behind a **frozen ABI**; every other
 surface — Go services, TypeScript SDKs and MCP servers, the Rust CLI, the
 dashboard — binds to that one contract. gal is Apache-2.0, open core, and you
-can **self-host the whole platform today**.
+build the whole platform **from source today**:
 
 ```bash
-# self-host the OSS platform
-docker compose -f deploy/docker-compose.yml up
+# build everything from source, in ABI order (kernel header first)
+just all          # or `just kernel` / `just services` for one ecosystem
 ```
+
+> **Self-host via Docker Compose is a work-in-progress.**
+> [`deploy/docker-compose.yml`](deploy/docker-compose.yml) is a **skeleton**: the
+> per-service images (`ghcr.io/gal-run/<svc>:dev`) are not yet published, and the
+> Go services are currently skeleton binaries. To build the images locally,
+> uncomment the `build:` block under each service and run:
+>
+> ```bash
+> docker compose -f deploy/docker-compose.yml up --build
+> ```
+>
+> A pinned, published-image compose for one-command self-host is on the roadmap.
 
 ## Why kernel at head
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,7 +4,7 @@ This document maps customer-facing GAL components to our status page for service
 
 ## Status Page
 
-Check real-time service health at: **[status.gal.run](https://status.gal.run)**
+Check real-time service health at: **[status.scheduler-systems.com](https://status.scheduler-systems.com)**
 
 ## Service Components
 
@@ -31,13 +31,16 @@ Check real-time service health at: **[status.gal.run](https://status.gal.run)**
 When GAL APIs report degraded state, authenticated UI surfaces should display a banner:
 
 ```
-⚠️ GAL services are experiencing issues. Check status.gal.run for updates.
+⚠️ GAL services are experiencing issues. Check status.scheduler-systems.com for updates.
 ```
 
 This messaging:
 - Informs users of known issues
 - Directs them to the status page
 - Avoids implying user misconfiguration
+
+The canonical status page is **[status.scheduler-systems.com](https://status.scheduler-systems.com)**
+(the central Scheduler Systems status page — see [`docs/status-components.md`](docs/status-components.md)).
 
 ## Incident Communication
 
@@ -53,4 +56,4 @@ Planned maintenance windows are announced on the status page at least 24 hours i
 
 ## Support
 
-For service issues not reflected on the status page, contact support@gal.run.
+For service issues not reflected on the status page, contact support@scheduler-systems.com.

--- a/apps/browser-extension/INSTALL.md
+++ b/apps/browser-extension/INSTALL.md
@@ -168,6 +168,6 @@ The extension:
 ## Support
 
 For issues or questions:
-- GitHub Issues: https://github.com/your-org/gal/issues
-- Documentation: https://docs.gal.run
-- Email: support@gal.run
+- GitHub Issues: https://github.com/gal-run/gal/issues
+- Documentation: https://gal.run
+- Email: support@scheduler-systems.com

--- a/apps/browser-extension/src/lib/service-degradation.ts
+++ b/apps/browser-extension/src/lib/service-degradation.ts
@@ -7,7 +7,7 @@ export interface ServiceDegradation {
   detectedAt: number;
 }
 
-const STATUS_PAGE_URL = "https://status.gal.run";
+const STATUS_PAGE_URL = "https://status.scheduler-systems.com";
 const DEGRADATION_COOLDOWN_MS = 60_000;
 const MAX_STORED_DEGRADATIONS = 5;
 

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -270,7 +270,7 @@ Access your organization's dashboard at [app.gal.run](https://app.gal.run)
 
 ## Service Status
 
-Check service health at **[status.gal.run](https://status.gal.run)** — see [STATUS.md](../../STATUS.md) for component mapping.
+Check service health at **[status.scheduler-systems.com](https://status.scheduler-systems.com)** — see [STATUS.md](../../STATUS.md) for component mapping.
 
 ## Support
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,9 +1,15 @@
-# deploy/docker-compose.yml - self-host stub.
-# "self-host today": bring up the OSS governance + gateway + auth services
-# against a local Postgres. Per-service images publish to
-# ghcr.io/gal-run/<svc>:<ver>; this compose pins :dev placeholders.
+# deploy/docker-compose.yml - self-host skeleton (work-in-progress).
 #
-# Real images are built per service from deploy/Dockerfile.<svc> (skeleton).
+# This brings up the OSS governance + gateway + auth services against a local
+# Postgres. The per-service images (ghcr.io/gal-run/<svc>:dev) are NOT yet
+# published, so the `image:` lines are placeholders. Build them locally with:
+#
+#     docker compose -f deploy/docker-compose.yml up --build
+#
+# Each service is built from deploy/Dockerfile.service (SVC arg selects the
+# binary). NOTE: the Go services are currently skeleton binaries that print
+# their ABI version and exit; this compose is not yet a one-command running
+# platform. A pinned, published-image compose is on the roadmap.
 version: "3.9"
 
 services:
@@ -18,7 +24,12 @@ services:
 
   governance:
     image: ghcr.io/gal-run/governance:dev
-    # build: { context: .., dockerfile: deploy/Dockerfile.service, args: { SVC: governance } }
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.service
+      args:
+        SVC: governance
+        GAL_OSS: "1"
     environment:
       # ee features stay inert unless a valid signed key is supplied.
       GAL_LICENSE_KEY: ""
@@ -27,6 +38,12 @@ services:
 
   gateway:
     image: ghcr.io/gal-run/gateway:dev
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.service
+      args:
+        SVC: gateway
+        GAL_OSS: "1"
     environment:
       GAL_LICENSE_KEY: ""
     ports:
@@ -35,4 +52,10 @@ services:
 
   auth:
     image: ghcr.io/gal-run/auth:dev
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.service
+      args:
+        SVC: auth
+        GAL_OSS: "1"
     depends_on: [postgres]

--- a/kernel/.gitignore
+++ b/kernel/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 # --- C build artifacts (never commit; DWARF embeds absolute local paths) ---
 *.o
 *.a
+*.so
 *.dSYM/
 /test/test_kernel
 /test/test_shell

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -7,11 +7,28 @@ KSRC    := src/gal_kernel.c
 SSRC    := src/gal_kernel.c src/gal_decide.c
 KTEST   := test/test_kernel
 STEST   := test/test_shell
+LIBNAME := gal_decide
+STATICLIB := lib$(LIBNAME).a
+SHAREDLIB := lib$(LIBNAME).so
 
-.PHONY: all test asan cppcheck clean
+.PHONY: all lib test asan cppcheck clean
 
 all:
 	$(CC) $(CFLAGS) -c $(KSRC) -o /dev/null
+
+# Build the consumer-ABI libraries (libgal_decide.{a,so}) that downstream
+# cgo bindings and services link against. Compiled position-independent so the
+# same objects archive into the static lib and link into the shared lib.
+# deploy/Dockerfile.service runs `make lib` and COPYs both artifacts.
+lib: $(STATICLIB) $(SHAREDLIB)
+
+$(STATICLIB): $(SSRC)
+	$(CC) $(CFLAGS) -fPIC -c src/gal_kernel.c -o src/gal_kernel.o
+	$(CC) $(CFLAGS) -fPIC -c src/gal_decide.c -o src/gal_decide.o
+	$(AR) rcs $@ src/gal_kernel.o src/gal_decide.o
+
+$(SHAREDLIB): $(SSRC)
+	$(CC) $(CFLAGS) -fPIC -shared $(SSRC) -o $@
 
 # Build + run unit tests (kernel core + JSON shell).
 test:
@@ -35,4 +52,4 @@ cppcheck:
 		--suppress='*:third_party/*' --error-exitcode=1 -Iinclude -Ithird_party src test
 
 clean:
-	rm -f $(KTEST) $(STEST) $(KTEST)-asan $(STEST)-asan src/*.o
+	rm -f $(KTEST) $(STEST) $(KTEST)-asan $(STEST)-asan src/*.o $(STATICLIB) $(SHAREDLIB)


### PR DESCRIPTION
Readiness fixes for the public repo (docs/config + one verified build fix).

## What
- **README**: stop claiming a one-command compose self-host (the `:dev` ghcr images are unpublished and the `build:` blocks were commented). Lead with the working from-source path (`just all`); label `deploy/docker-compose.yml` as a WIP skeleton and document `docker compose up --build`.
- **deploy/docker-compose.yml**: add `build:` blocks (Dockerfile.service, `SVC` + `GAL_OSS=1`) for governance/gateway/auth; honest header. `docker compose config` validates.
- **kernel/Makefile**: add the missing `lib` target emitting `libgal_decide.{a,so}`. `deploy/Dockerfile.service` runs `make lib` and COPYs both — previously `make lib` did not exist, so the documented service-image build was broken. `clean` removes the artifacts; `.gitignore` ignores `*.so`.
- **Doc drift**: point STATUS/support consistently at `status.scheduler-systems.com` / `support@scheduler-systems.com` — the targets that actually resolve / accept mail (`status.gal.run` returns no response and `gal.run` has no MX). Fixes `STATUS.md`, the browser-extension service-degradation banner URL, `apps/console/README.md`, `apps/browser-extension/INSTALL.md`.

## Verification
- `kernel`: `make all`, `make test`, `make lib` all green; `lib` exports the full ABI (`gal_decide`, `gal_engine_new`, ...).
- `docker compose -f deploy/docker-compose.yml config` valid.
- gitleaks clean under the repo's own configs; no founder PII introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)