### PR TITLE
Fix README accuracy: kernel ref, Homebrew tap, monorepo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ just all          # or `just kernel` / `just services` for one ecosystem
 
 ## Why kernel at head
 
-The reference monitor (`kernel/`, pure C — a clean copy of the public
-`gal-run/gal-kernel`) is the single contract the entire monorepo binds to. Its
+The reference monitor (`kernel/`, pure C) is the single contract the entire
+monorepo binds to. Its
 ABI — `kernel/include/gal_decide.h` — is frozen and append-only, so consumers in
 any language **embed it via the C ABI**. Builds run in **ABI order**: the kernel
 is built first, then everything downstream (the Go cgo binding, codegen
@@ -44,17 +44,21 @@ consumers, the rest).
 
 ## Monorepo layout
 
-| Path        | Lang  | What                                                              | Ships as |
-|-------------|-------|-------------------------------------------------------------------|----------|
-| `kernel/`   | C     | pure-C reference monitor (core + JSON shell) + frozen C ABI + tests | source (embedded via C ABI) + header |
-| `services/` | Go    | governance, auth, gateway, mcp-gateway, dispatch, repo, sdlc, team, swarm, gal-rag | `ghcr.io/gal-run/<svc>` images |
-| `sdks/`     | TS    | agents-schema, agent-network, swarm, prediction, contracts        | npm `@gal-run/*` |
-| `mcp/`      | TS    | mcp-chrome, mcp-terminal, mcp-ide, mcp-vision                     | npm `@gal-run/mcp-*` |
-| `apps/`     | TS/JS | `dashboard/` (Next.js, deployed), `console/` (relocated legacy app) | deployed |
-| `cli/`      | Rust  | `gal-cli`                                                         | crates.io + Homebrew tap |
-| `deploy/`   | —     | Dockerfiles, helm/argocd/IaC, docker-compose                     | — |
-| `docs/`     | —     | architecture, ABI spec, EE policy, runbooks                      | — |
-| `tools/`    | —     | license-fence, codegen, ci helpers                               | — |
+| Path          | Lang   | What                                                              | Ships as |
+|---------------|--------|-------------------------------------------------------------------|----------|
+| `kernel/`     | C      | pure-C reference monitor (core + JSON shell) + frozen C ABI + tests | source (embedded via C ABI) + header |
+| `services/`   | Go     | auth, gateway, mcp-gateway, mcp, dispatch, repo, sdlc, team, swarm, governance, gal-rag, gal-inference, mal | `ghcr.io/gal-run/<svc>` images |
+| `sdks/`       | TS     | agents-schema, agent-network, contracts, swarm, prediction, evals, sandbox | npm `@gal-run/*` |
+| `mcp/`        | TS     | chrome, terminal, ide, vision, computer-use, gal-mcp             | npm `@gal-run/mcp-*` |
+| `apps/`       | TS/JS  | `dashboard/` (Next.js, deployed), `console/`, `website/`, browser/chrome extensions, accessibility-app | deployed |
+| `packages/`   | TS     | `gal-code` — the coding agent (app + desktop/electron)           | app |
+| `agents/`     | Rust   | `agent-os`, `super-agent`                                        | source |
+| `cli/`        | Rust   | `gal-cli`                                                        | crates.io + in-repo Homebrew tap (`Formula/`, `Casks/`) |
+| `model/`      | Python | `gal-model` — deep-learning governance model (train/eval/inference, eval-worker + sidecar) | source |
+| `governance/` | —      | `si-bootstrap` — governance bootstrap (policies + scripts)       | — |
+| `deploy/`     | —      | Dockerfiles, helm/argocd/IaC, docker-compose                    | — |
+| `docs/`       | —      | architecture, ABI spec, EE policy, runbooks                     | — |
+| `tools/`      | —      | license-fence, codegen, ci helpers                              | — |
 
 ## Build
 
@@ -81,8 +85,9 @@ Every commit message must contain `[ci]`.
 ## Install the CLI
 
 ```bash
-# Homebrew
-brew install gal-run/tap/gal
+# Homebrew (formula + cask live in this repo)
+brew tap gal-run/gal https://github.com/gal-run/gal
+brew install gal-run/gal/gal
 
 # crates.io
 cargo install gal-cli

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ consumers, the rest).
 | `kernel/`     | C      | pure-C reference monitor (core + JSON shell) + frozen C ABI + tests | source (embedded via C ABI) + header |
 | `services/`   | Go     | auth, gateway, mcp-gateway, mcp, dispatch, repo, sdlc, team, swarm, governance, gal-rag, gal-inference, mal | `ghcr.io/gal-run/<svc>` images |
 | `sdks/`       | TS     | agents-schema, agent-network, contracts, swarm, prediction, evals, sandbox | npm `@gal-run/*` |
-| `mcp/`        | TS     | chrome, terminal, ide, vision, computer-use, gal-mcp             | npm `@gal-run/mcp-*` |
+| `mcp/`        | TS     | chrome, terminal, ide, vision, computer-use, gal-mcp             | npm `@gal-run/gal-*-mcp` |
 | `apps/`       | TS/JS  | `dashboard/` (Next.js, deployed), `console/`, `website/`, browser/chrome extensions, accessibility-app | deployed |
 | `packages/`   | TS     | `gal-code` — the coding agent (app + desktop/electron)           | app |
 | `agents/`     | Rust   | `agent-os`, `super-agent`                                        | source |
@@ -64,6 +64,10 @@ consumers, the rest).
 
 The root `justfile` (mirrored by a thin `Makefile`) delegates to each
 ecosystem's native tool — no Bazel.
+
+> **First-time setup:** `just all` compiles but does not install dependencies.
+> Run `npm install` (repo root — the `sdks/` + `mcp/` + `apps/` TS workspace) and
+> `bun install` in `packages/gal-code` once before building those ecosystems.
 
 ```bash
 just kernel     # make/cc  -> compile pure-C core (frozen C ABI header)
@@ -101,8 +105,9 @@ gal sync              # distribute the canonical config to your agents
 
 ## MCP servers
 
-gal publishes MCP servers as standalone npm packages: `@gal-run/mcp-chrome`,
-`@gal-run/mcp-terminal`, `@gal-run/mcp-ide`, `@gal-run/mcp-vision`. The hosted
+gal publishes MCP servers as standalone npm packages: `@gal-run/gal-chrome-mcp`,
+`@gal-run/gal-terminal-use-mcp`, `@gal-run/gal-ide-use-mcp`, `@gal-run/gal-vision-mcp`,
+`@gal-run/gal-computer-use-mcp`, and `@gal-run/gal-mcp`. The hosted
 governance MCP endpoint is `https://api.gal.run/mcp` (OAuth on first use):
 
 ```json


### PR DESCRIPTION
Addresses #423

Three accuracy fixes to the public README, found while auditing the repo for public-appropriateness. README-only change, no code touched.

### 1. Kernel no longer claims a non-public repo
"Why kernel at head" described `kernel/` as "a clean copy of the **public** `gal-run/gal-kernel`". That repo returns 404 — it is not public (`gal-run/gal` is the org's only public repo), so the reference is dead for readers. Dropped the dangling claim; the kernel lives in `kernel/`.

### 2. Homebrew install command now works
`brew install gal-run/tap/gal` resolves to tap repo `gal-run/homebrew-tap`, which does not exist (404). The formula and cask actually live in this repo (`Formula/gal.rb`, `Casks/gal.rb`), so the README now taps this repo directly:

```
brew tap gal-run/gal https://github.com/gal-run/gal
brew install gal-run/gal/gal
```

(`cargo install gal-cli` was already correct — crates.io v0.1.2.)

### 3. Monorepo layout table completed
The table omitted four real top-level dirs — `packages/` (gal-code, ~4.5k files), `model/` (gal-model), `agents/`, `governance/` — and several existing rows were stale (`apps/` listed 2 of 6 apps; `mcp/`, `sdks/`, `services/` were missing entries). Refreshed every row against the actual `main` tree.

All referenced files/paths verified to exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
