### PR TITLE
Security: remediate reachable Dependabot criticals/highs (golang-jwt, quinn-proto, rustls-webpki)

### DIFF
--- a/packages/gal-code/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/gal-code/packages/desktop/src-tauri/Cargo.lock
@@ -3737,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4163,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/services/go.mod
+++ b/services/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/httprate v0.14.1
 	github.com/go-chi/jwtauth/v5 v5.3.2
-	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lestrrat-go/jwx/v2 v2.1.3

--- a/services/go.sum
+++ b/services/go.sum
@@ -103,8 +103,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Addresses #423

Remediation from a reachability-assessed triage of the repo's open critical+high Dependabot alerts (2 critical, 32 high). This PR fixes the items that are **actually reachable and clean to patch**; the rest are deferred with rationale below.

## Fixed here (3 deps, lockfiles refreshed cleanly)

| Dep | Bump | CVE / advisory | Why it's in scope |
|---|---|---|---|
| `golang-jwt/jwt/v5` (services) | `5.2.1 → 5.2.2` | CVE-2025-30204 — memory-alloc DoS on JWT header parsing | **The one prod-reachable item.** Direct dep; `auth-svc` parses untrusted `Authorization` headers (`jwt.Parse`, `ParseUnverified`). `go.sum` tidied. |
| `quinn-proto` (desktop tauri) | `0.11.13 → 0.11.14` | CVE-2026-31812 — unauth remote DoS via QUIC panic | Transitive; `Cargo.lock` only. |
| `rustls-webpki` (desktop tauri) | `0.103.8 → 0.103.13` | GHSA-82j2-j2ch-gfr8 — DoS via panic on malformed CRL | Transitive; `Cargo.lock` only. |

Diff is **3 files, +7/−7** — no lockfile churn.

## Deferred (low real risk — separate passes)
- **The 2 "criticals" (`vitest`)** are **not reachable**: `@vitest/ui` isn't installed and the UI server is never started. Accept/dismiss.
- **`next` (5 highs)** — the installed version is already **15.5.19 ≥ patched 15.5.16**; the alert is stale. No change needed.
- **`electron` (5 highs)** — adversarial verify found the renderer only loads **local** files (no remote/untrusted web content reaches it), so the cited RCE-class CVEs aren't reachable. Worth a same-line `40.4.1 → 40.8.0` hygiene bump in a bun-workspace pass.
- **`docker` / `containerd`** (incl. 2 *no-fix* advisories) — transitive via **testcontainers** = test tooling, not production.
- **`jpeg-js`** — only enters via a **dead** `png-to-jpeg` dep in `mcp/computer-use`; removing it is correct, but the root `package-lock.json` is stale and a clean regen churns ~2.6k lines, so it belongs in a dedicated lock-cleanup PR.
- **bun-workspace bumps** (`astro`, `@astrojs/cloudflare`, `hono`, `minimatch`, `fast-uri`, `wrangler`, `vite`) — trivial but need a `bun.lock` refresh; grouped for one follow-up.

Full per-package triage (reachability, shipped-status, priority) available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Review note:** CVE-2025-30204 (golang-jwt) is severity **HIGH**, not critical — the only *critical* alerts in the triaged set were the `vitest` UI alerts (deferred as not-reachable). All three fixes here are HIGH, each independently verified to land exactly on its CVE first-patched version.