### PR TITLE
cli: route diagnostic logs to stderr so MCP JSON-RPC on stdout isn't corrupted [ci]

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -170,6 +170,10 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env().add_directive("gal=info".parse()?))
         .with_target(false)
+        // Diagnostic logs MUST go to stderr: the MCP servers (terminal/vision/browser/
+        // chrome-extension/computer-use) speak JSON-RPC 2.0 over stdout, so any log line
+        // on stdout corrupts the protocol stream for the connected client.
+        .with_writer(std::io::stderr)
         .init();
 
     let cli = Cli::parse();


### PR DESCRIPTION
## What
One-line fix in `cli/src/main.rs`: route `tracing` diagnostic output to **stderr** via `.with_writer(std::io::stderr)`.

## Why
`gal`'s MCP server subcommands (`terminal`, `vision`, `browser`, chrome-extension, computer-use) speak **JSON-RPC 2.0 over stdout**. The subscriber defaulted to stdout, so any log line corrupts the protocol stream for the connected client. stdout is now reserved exclusively for JSON-RPC.

## Provenance
Ports the fix from the archived pre-consolidation Rust CLI (`gal-run/gal-cli-rs-private` PR #13); it was not carried into the monorepo during open-core consolidation. Surfaced by the archived-repo disposition audit (2026-06-19).

## Test
`cargo check` passes (only pre-existing warnings). No behavior change beyond log destination.

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)