### PR TITLE
auth-svc: add GET /auth/me back-compat alias [ci]

### DIFF
--- a/services/auth-svc/cmd/server/main.go
+++ b/services/auth-svc/cmd/server/main.go
@@ -693,6 +693,10 @@ func main() {
 		r.Delete("/auth/session", svc.handleLogout)
 
 		r.Get("/users/me", svc.handleGetMe)
+		// Back-compat alias: older clients (gal CLI <=0.1.0, mcp-svc, gal-cli-ts)
+		// call GET /auth/me to fetch the current user. Keep this until those
+		// callers migrate to /users/me so the auth-svc cutover doesn't 404 them.
+		r.Get("/auth/me", svc.handleGetMe)
 		r.Patch("/users/me", svc.handleUpdateMe)
 		r.Get("/users/me/settings", svc.handleGetSettings)
 		r.Patch("/users/me/settings", svc.handleUpdateSettings)


### PR DESCRIPTION
## What
Adds `GET /auth/me` as a back-compat alias for the existing `GET /users/me` handler (`handleGetMe`) in `auth-svc`.

## Why
Clients are migrating to `/users/me`, but some still call `GET /auth/me` to fetch the current user (e.g. `mcp-svc`, older CLI builds). Serving `/auth/me` as an alias to the same handler keeps those callers working during the transition; remove once all callers use `/users/me`.

Addresses #455.

## Testing
The `services` CI job builds `auth-svc`. The change is a single route registration pointing at the same `handleGetMe` handler as the adjacent `/users/me` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
