### PR TITLE
ci: add gal-code bun-workspace coverage (typecheck + astro build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@
 #   cli       <- cli/**
 #   agents    <- agents/**                           (separate cargo workspace)
 #   model     <- model/**                            (Python ML governance model)
+#   gal-code  <- packages/gal-code/**                 (bun workspace: typecheck + astro build)
 #   fence     <- ALWAYS (fast license check)
 #
 # Repo ruleset: every commit message must contain "[ci]".
@@ -32,6 +33,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       agents: ${{ steps.filter.outputs.agents }}
       model: ${{ steps.filter.outputs.model }}
+      gal_code: ${{ steps.filter.outputs.gal_code }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -53,6 +55,8 @@ jobs:
               - 'agents/**'
             model:
               - 'model/**'
+            gal_code:
+              - 'packages/gal-code/**'
 
   # Always-on, fast license-by-location fence.
   fence:
@@ -161,3 +165,25 @@ jobs:
           make train-smoke PYTHON=python
           make infer-smoke PYTHON=python
           make eval-smoke PYTHON=python
+
+  # gal-code is a SEPARATE bun workspace (not part of the npm/turbo `ts` job),
+  # so it had no CI coverage. Mirrors the local validation: install (frozen),
+  # turbo typecheck across all gal-code packages, and the astro web build
+  # (the web package has no typecheck task, so build is its coverage).
+  gal-code:
+    needs: changes
+    if: ${{ needs.changes.outputs.gal_code == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/gal-code
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: "1.3.13" }
+      - name: install (frozen lockfile)
+        run: bun install --frozen-lockfile
+      - name: typecheck (turbo, all gal-code packages)
+        run: bun run typecheck
+      - name: astro build (web app)
+        run: bun run --cwd packages/web build


### PR DESCRIPTION
Addresses #423.

## The gap
`packages/gal-code` is a **separate bun workspace** — it's *not* part of the npm/turbo `ts` job (which covers `sdks/`, `mcp/`, `apps/`). So it had **zero CI coverage**: the recent dependency bumps (electron, astro, etc. in #449) were only ever validated locally. Any future gal-code change merges unverified.

## The fix
A path-filtered `gal-code` job, gated on `packages/gal-code/**`, mirroring exactly the local validation that's been used:

```yaml
- bun install --frozen-lockfile
- bun run typecheck                 # turbo, all gal-code packages
- bun run --cwd packages/web build  # astro; the web pkg has no typecheck task
```

Scoped to **typecheck + build** (not the native electron/tauri packaging or the full test suite) — that's what answers "does gal-code still compile/build," keeps CI fast, and matches what's already validated by hand.

## Validation
- YAML parses clean; **`actionlint` passes with no findings**.
- The three steps are the same ones run locally on the #449 bumps: install clean, `typecheck` **13/13**, `astro build` exit 0.

## Note for reviewers
This PR only touches `.github/workflows/ci.yml`, so by the repo's own path-filter design the new `gal-code` job **does not run on this PR** — it first exercises on the next `packages/gal-code/**` change. If you'd like pre-merge proof, I can push a throwaway gal-code touch to trigger it once and then drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
