### PR TITLE
ci: manual trusted-publishing workflow for @gal-run/gal-agents [ci]

### DIFF
--- a/.github/workflows/publish-agents-schema.yml
+++ b/.github/workflows/publish-agents-schema.yml
@@ -1,0 +1,57 @@
+name: Publish agents-schema
+
+# Manually-triggered trusted publish of @gal-run/gal-agents (sdks/agents-schema)
+# to the public npm registry via OIDC — no long-lived token, no 2FA prompt.
+#
+# One-time setup on npmjs.com (account/org owner): configure a Trusted Publisher
+# for the @gal-run/gal-agents package ->
+#   Repository: gal-run/gal
+#   Workflow:   publish-agents-schema.yml
+#   Environment: (leave blank)
+# Docs: https://docs.npmjs.com/trusted-publishers
+#
+# Bump sdks/agents-schema/package.json "version" before running (npm refuses to
+# republish an existing version). Use the dry-run input first to validate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Pack and validate only — do NOT publish"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write # required for npm trusted publishing (OIDC) + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm (trusted publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install workspace dependencies
+        run: npm install
+
+      - name: Type-check, build, and test @gal-run/gal-agents
+        run: |
+          npm run type-check -w @gal-run/gal-agents
+          npm run build -w @gal-run/gal-agents
+          npm run test -w @gal-run/gal-agents
+
+      - name: Publish (dry run)
+        if: ${{ inputs.dry-run }}
+        run: npm publish -w @gal-run/gal-agents --provenance --access public --dry-run
+
+      - name: Publish to npm via trusted publishing (OIDC)
+        if: ${{ !inputs.dry-run }}
+        run: npm publish -w @gal-run/gal-agents --provenance --access public


### PR DESCRIPTION
## What
Adds `.github/workflows/publish-agents-schema.yml` — a **`workflow_dispatch`** (manual) job that publishes **`@gal-run/gal-agents`** (`sdks/agents-schema`) to public npm via **OIDC trusted publishing**:
- `permissions: id-token: write` → `npm publish --provenance --access public`, **no long-lived token, no 2FA prompt**
- mirrors CI conventions (`setup-node@v4` node 20, `npm install`), upgrades to `npm@latest` (trusted publishing needs npm ≥ 11.5.1)
- type-checks + builds + tests the package before publishing
- has a **`dry-run`** input to validate without publishing

## Why
The `@gal-run/*` sdks have no publish pipeline yet (CI only builds/tests; `sync-release.yml` is for the CLI). This is the first sdk publish path. Local `npm publish` is blocked by the account's security-key 2FA — trusted publishing (OIDC) is the correct, tokenless route and matches how we publish elsewhere.

## One-time setup before first run (account/org owner)
Configure a **Trusted Publisher** on npmjs.com for `@gal-run/gal-agents`:
- Repository: `gal-run/gal`
- Workflow: `publish-agents-schema.yml`

(For a brand-new package, the first publish may need npm's new-package-OIDC support or a one-time automation-token publish; subsequent releases go through this workflow.)

## How to run
Bump `sdks/agents-schema/package.json` version → Actions → **Publish agents-schema** → Run (toggle `dry-run` first to validate).

## Safety
No untrusted event input flows into any `run:` step (only a boolean `dry-run` used in `if:`); no command-injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #462
