### PR TITLE
README: fix CLI quickstart (gal approve --local is not a real command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ cargo install gal-cli
 
 ```bash
 gal scan              # discover existing AI agent configs
-gal approve --local   # standardize into ~/.gal/config.yaml
-gal sync              # distribute the canonical config to your agents
+gal init              # scaffold gal config in this project (.gal/config.yaml)
+gal sync              # pull + apply the approved org config (~/.gal/config.yaml)
 ```
 
 ## MCP servers


### PR DESCRIPTION
Addresses #423.

The CLI quickstart advertised a **command that doesn't exist**:

```
gal approve --local   # standardize into ~/.gal/config.yaml
```

`gal approve` is the **proposal-approval** command (`list` / `get <id>` / `set <id>` against the API — see `cli/src/commands/approve.rs`), and **no `--local` flag exists anywhere** in the CLI (`git grep 'long = "local"'` → zero matches). A reader copy-pasting it gets an error.

Replaced with real, source-verified commands:

```
gal scan              # discover existing AI agent configs        (unchanged — real)
gal init              # scaffold gal config in this project (.gal/config.yaml)
gal sync              # pull + apply the approved org config (~/.gal/config.yaml)
```

- `gal init` (`commands/init.rs`) scaffolds `.gal/config.yaml` in the project.
- `gal sync` (`commands/sync.rs`) "Download and apply org configs" and writes `~/.gal/config.yaml` — so the old `# distribute…` comment was also off (`distribute` is a separate command).

README-only; verified against `cli/src/main.rs` + the command modules on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
