### PR TITLE
web: vendor toolbeam-docs-theme + drop the dead dependency (unblocks future upgrades)

### DIFF
--- a/packages/gal-code/bun.lock
+++ b/packages/gal-code/bun.lock
@@ -614,7 +614,6 @@
         "remeda": "catalog:",
         "shiki": "catalog:",
         "solid-js": "catalog:",
-        "toolbeam-docs-theme": "0.4.8",
         "vscode-languageserver-types": "3.17.5",
       },
       "devDependencies": {
@@ -4679,8 +4678,6 @@
     "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
-
-    "toolbeam-docs-theme": ["toolbeam-docs-theme@0.4.8", "", { "peerDependencies": { "@astrojs/starlight": "^0.34.3", "astro": "^5.7.13" } }, "sha512-b+5ynEFp4Woe5a22hzNQm42lD23t13ZMihVxHbzjA50zdcM9aOSJTIjdJ0PDSd4/50HbBXcpHiQsz6rM4N88ww=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/packages/gal-code/packages/web/astro.config.mjs
+++ b/packages/gal-code/packages/web/astro.config.mjs
@@ -3,7 +3,6 @@ import { defineConfig } from "astro/config"
 import starlight from "@astrojs/starlight"
 import solidJs from "@astrojs/solid-js"
 import cloudflare from "@astrojs/cloudflare"
-import theme from "toolbeam-docs-theme"
 import config from "./config.mjs"
 import { rehypeHeadingIds } from "@astrojs/markdown-remark"
 import rehypeAutolinkHeadings from "rehype-autolink-headings"
@@ -165,7 +164,20 @@ export default defineConfig({
       markdown: {
         headingLinks: false,
       },
-      customCss: ["./src/styles/custom.css"],
+      // Was injected by the toolbeam-docs-theme plugin (now vendored). Order
+      // preserved: fonts + vendored theme CSS, then the site's own custom.css.
+      customCss: [
+        "@fontsource/ibm-plex-mono/400.css",
+        "@fontsource/ibm-plex-mono/400-italic.css",
+        "@fontsource/ibm-plex-mono/500.css",
+        "@fontsource/ibm-plex-mono/600.css",
+        "@fontsource/ibm-plex-mono/700.css",
+        "./src/vendor/docs-theme/styles/theme.css",
+        "./src/vendor/docs-theme/styles/tsdoc.css",
+        "./src/vendor/docs-theme/styles/markdown.css",
+        "./src/vendor/docs-theme/styles/headings.css",
+        "./src/styles/custom.css",
+      ],
       logo: {
         light: "./src/assets/logo-light.svg",
         dark: "./src/assets/logo-dark.svg",
@@ -298,12 +310,10 @@ export default defineConfig({
         Header: "./src/components/Header.astro",
         Footer: "./src/components/Footer.astro",
         SiteTitle: "./src/components/SiteTitle.astro",
+        // Was provided by the toolbeam-docs-theme plugin; now vendored.
+        PageTitle: "./src/vendor/docs-theme/overrides/PageTitle.astro",
       },
-      plugins: [
-        theme({
-          headerLinks: config.headerLinks,
-        }),
-      ],
+      pagination: false,
     }),
   ],
 })

--- a/packages/gal-code/packages/web/package.json
+++ b/packages/gal-code/packages/web/package.json
@@ -32,7 +32,6 @@
     "remeda": "catalog:",
     "shiki": "catalog:",
     "solid-js": "catalog:",
-    "toolbeam-docs-theme": "0.4.8",
     "vscode-languageserver-types": "3.17.5"
   },
   "devDependencies": {

--- a/packages/gal-code/packages/web/src/components/Header.astro
+++ b/packages/gal-code/packages/web/src/components/Header.astro
@@ -3,7 +3,7 @@ import config from "../../config.mjs"
 import astroConfig from "virtual:starlight/user-config"
 import { getRelativeLocaleUrl } from "astro:i18n"
 import { Icon } from "@astrojs/starlight/components"
-import Default from "toolbeam-docs-theme/overrides/Header.astro"
+import Default from "../vendor/docs-theme/overrides/Header.astro"
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro"
 
 const path = Astro.url.pathname

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/LICENSE
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SST
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/README.md
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/README.md
@@ -1,0 +1,14 @@
+# Vendored: toolbeam-docs-theme
+
+Vendored from `toolbeam-docs-theme@0.4.8` (npm) — MIT, see [`LICENSE`](./LICENSE).
+
+The upstream package is unmaintained (pinned to `@astrojs/starlight ^0.34.3`),
+which blocked every Starlight/astro upgrade. Only the files this site actually
+uses are vendored: the 4 style sheets, the `Header` + `PageTitle` overrides, and
+the `HeaderLinks` component.
+
+The theme's plugin behavior (font + CSS `customCss` injection, the `PageTitle`
+component override, `pagination: false`) is now expressed directly in
+`packages/web/astro.config.mjs`. `components/HeaderLinks.astro` was adjusted to
+read `config.headerLinks` from `packages/web/config.mjs` instead of the plugin's
+`globalThis.toolbeamDocsThemeConfig`.

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/components/HeaderLinks.astro
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/components/HeaderLinks.astro
@@ -1,0 +1,22 @@
+---
+// Vendored from toolbeam-docs-theme (see ../LICENSE). Originally read
+// globalThis.toolbeamDocsThemeConfig (set by the theme plugin); now reads the
+// site config directly so no plugin/global is needed.
+import config from "../../../../config.mjs"
+const { headerLinks } = config
+---
+{
+  headerLinks?.map(({ name, url }) => (
+    <a class="links" href={url}>{name}</a>
+  ))
+}
+
+<style>
+  a.links {
+		text-transform: uppercase;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-text-secondary);
+    line-height: normal;
+  }
+</style>
+

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/overrides/Header.astro
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/overrides/Header.astro
@@ -1,0 +1,122 @@
+---
+import config from "virtual:starlight/user-config";
+import type { Props } from "@astrojs/starlight/props";
+
+import Search from "virtual:starlight/components/Search";
+import SiteTitle from "virtual:starlight/components/SiteTitle";
+import SocialIcons from "virtual:starlight/components/SocialIcons";
+import { Icon } from "@astrojs/starlight/components";
+import HeaderLinks from "../components/HeaderLinks.astro";
+
+/**
+ * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
+ */
+const shouldRenderSearch =
+	config.pagefind ||
+	config.components.Search !== "@astrojs/starlight/components/Search.astro";
+
+const links = config.social || [];
+---
+
+<div class="header sl-flex">
+	<div class="title-wrapper sl-flex">
+		<SiteTitle {...Astro.props} />
+	</div>
+	<div class="middle-group sl-flex">
+		<HeaderLinks {...Astro.props} />
+	</div>
+	<div class="sl-hidden md:sl-flex right-group">
+		{
+			links.length > 0 && (
+				<div class="sl-flex social-icons">
+					{links.map(({ href, icon }) => (
+						<a {href} rel="me" target="_blank">
+							<Icon name={icon} size="1rem" />
+						</a>
+					))}
+				</div>
+			)
+		}
+		{shouldRenderSearch && <Search {...Astro.props} />}
+	</div>
+</div>
+
+<style>
+	.header {
+		gap: calc(var(--sl-nav-gap) * 2);
+		justify-content: space-between;
+		align-items: center;
+		height: 100%;
+	}
+
+	.title-wrapper {
+		/* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
+		overflow: clip;
+		/* Avoid clipping focus ring around link inside title wrapper. */
+    padding: calc(0.25rem + 2px) 0.25rem calc(0.25rem - 2px);
+		margin: -0.25rem;
+	}
+
+	.middle-group {
+		justify-content: flex-end;
+		gap: var(--sl-nav-gap);
+	}
+	@media (max-width: 50rem) {
+		:global(:root[data-has-sidebar]) {
+			.middle-group {
+				display: none;
+			}
+		}
+	}
+	@media (min-width: 50rem) {
+		.middle-group {
+			display: flex;
+		}
+	}
+
+	.right-group,
+	.social-icons {
+		gap: 1rem;
+		align-items: center;
+
+    a {
+          line-height: 1;
+
+          svg {
+              color: var(--sl-color-text-dimmed);
+          }
+      }
+	}
+
+	@media (min-width: 50rem) {
+		:global(:root[data-has-sidebar]) {
+			--__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+		}
+		:global(:root:not([data-has-toc])) {
+			--__toc-width: 0rem;
+		}
+		.header {
+			--__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
+			--__main-column-fr: calc(
+				(
+						100% + var(--__sidebar-pad, 0rem) - var(--__toc-width, var(--sl-sidebar-width)) -
+							(2 * var(--__toc-width, var(--sl-nav-pad-x))) - var(--sl-content-inline-start, 0rem) -
+							var(--sl-content-width)
+					) / 2
+			);
+			display: grid;
+			grid-template-columns:
+        /* 1 (site title): runs up until the main content column’s left edge or the width of the title, whichever is the largest  */
+				minmax(
+					calc(var(--__sidebar-width) + max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
+					auto
+				)
+				/* 2 (search box): all free space that is available. */
+				1fr
+				/* 3 (right items): use the space that these need. */
+				auto;
+			align-content: center;
+		}
+	}
+</style>
+

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/overrides/PageTitle.astro
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/overrides/PageTitle.astro
@@ -1,0 +1,32 @@
+---
+import type { Props } from "@astrojs/starlight/props";
+
+const {
+	entry: {
+		data: { title, description },
+	},
+} = Astro.locals.starlightRoute;
+---
+
+<Fragment>
+  <h1 id="_top">{title}</h1>
+  { description && <p class="page-description">{description}</p> }
+</Fragment>
+
+<style>
+h1 {
+  font-weight: 600;
+  color: var(--sl-color-text);
+  line-height: var(--sl-line-height-headings);
+  font-size: var(--sl-text-h1);
+  font-family: var(--__sl-font-headings);
+  letter-spacing: -0.5px;
+  text-transform: uppercase;
+}
+p.page-description {
+  margin-top: 0.25rem;
+  line-height: 1.5;
+  color: var(--sl-color-text-secondary);
+}
+</style>
+

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/styles/headings.css
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/styles/headings.css
@@ -1,0 +1,14 @@
+/**
+ * Linkable headings
+ */
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) > a {
+	text-decoration: none;
+	cursor: none;
+	color: var(--sl-color-text);
+
+	&:hover {
+		cursor: pointer;
+		text-decoration: none;
+		color: var(--sl-color-text);
+	}
+}

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/styles/markdown.css
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/styles/markdown.css
@@ -1,0 +1,318 @@
+/**
+ * Paragraphs
+ */
+.sl-markdown-content :not(a, strong, em, del, span, input, code)
+  + :not(a, strong, em, del, span, input, code, :where(.not-content *)) {
+  margin-top: var(--paragraph-spacing);
+}
+/* Space around asides and code blocks */
+.sl-markdown-content :not(a, strong, em, del, span, input, code)
+  + :is(.starlight-aside, .expressive-code) {
+  margin-top: calc(var(--paragraph-spacing) + 0.4375rem);
+}
+/* .sl-markdown-content :is(.starlight-aside, .expressive-code, table) */
+/*   + :not(a, strong, em, del, span, input, code, h1, h2, h3, h4, h5, h6, :where(.not-content *)) { */
+/*   margin-top: calc(var(--paragraph-spacing) + 0.5rem); */
+/* } */
+.sl-markdown-content :is(.starlight-aside, .expressive-code)
+  + :is(.starlight-aside, .expressive-code) {
+  margin-top: calc(var(--paragraph-spacing) + 1.125rem);
+}
+/* Space around sections */
+.sl-markdown-content :not(h1, h2, h3, h4, h5, h6)
+  + :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)),
+.sl-markdown-content :not(a, strong, em, del, span, input, code)
+  + hr:not(:where(.not-content *)),
+.sl-markdown-content hr:not(:where(.not-content *)) + :not(a, strong, em, del, span, input, code, :where(.not-content *))
+{
+  margin-top: calc(var(--paragraph-spacing) + 2rem);
+}
+/**
+ * Links
+ */
+.sl-markdown-content a:not(:where(.not-content *)),
+.sl-markdown-content a:not(:where(.not-content *)) code {
+	color: var(--sl-color-text);
+	text-underline-offset: 0.25rem;
+	text-decoration: underline;
+}
+.sl-markdown-content a:hover:not(:where(.not-content *)) {
+	color: var(--sl-color-text);
+}
+
+/**
+ * Blockquotes
+ */
+.sl-markdown-content blockquote:not(:where(.not-content *)) {
+	border-inline-start: 2px solid var(--sl-color-hairline);
+	padding-inline-start: 1rem;
+	font-size: var(--sl-text-h5);
+	color: var(--color-text-secondary);
+}
+
+/**
+ * Inline code
+ */
+.sl-markdown-content code:not(:where(.not-content *)) {
+	padding: 0;
+	background: none;
+	font-weight: 600;
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-text);
+}
+.sl-markdown-content strong code:not(:where(.not-content *)) {
+	font-weight: 700;
+}
+.sl-markdown-content code:not(:where(.not-content *)):before,
+.sl-markdown-content code:not(:where(.not-content *)):after {
+	content: "`";
+}
+
+/**
+ * Code blocks
+ */
+/* Plain blocks */
+.sl-markdown-content
+	.expressive-code
+	.frame:not(.has-title):not(.is-terminal)
+	pre {
+	border-color: var(--sl-color-border);
+	border-radius: 0;
+	background-color: transparent;
+}
+.sl-markdown-content .expressive-code .copy {
+	inset-block-start: calc(var(--ec-brdWd) + var(--button-spacing) + 0.1rem);
+}
+.sl-markdown-content .expressive-code .copy .feedback {
+	--tooltip-bg: var(--sl-color-gray-3);
+
+	font-size: 0.75rem;
+	line-height: 1;
+	padding: 0.375rem 0.5rem;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+.sl-markdown-content .expressive-code .copy button {
+	width: 2rem;
+	height: 2rem;
+	border-radius: 0;
+	background-color: var(--sl-color-bg);
+
+	&::before {
+		opacity: 1;
+		border-color: var(--sl-color-border);
+	}
+
+	& div {
+		background-color: transparent;
+	}
+}
+@media (hover: hover) {
+	.sl-markdown-content .expressive-code .frame:hover .copy button:not(:hover),
+	.sl-markdown-content
+		.expressive-code
+		.frame:focus-within
+		:focus-visible
+		~ .copy
+		button:not(:hover),
+	.sl-markdown-content
+		.expressive-code
+		.frame
+		.copy
+		.feedback.show
+		~ button:not(:hover) {
+		opacity: 1;
+	}
+}
+/* Frames */
+.sl-markdown-content
+	.expressive-code
+	.frame.has-title:not(.is-terminal)
+	.header {
+	background: transparent;
+	border-bottom: 1px solid var(--sl-color-border);
+	border-radius: 0;
+}
+.sl-markdown-content
+	.expressive-code
+	.frame.has-title:not(.is-terminal)
+	.header:before {
+	border-color: var(--sl-color-border);
+}
+.sl-markdown-content
+	.expressive-code
+	.frame.has-title:not(.is-terminal)
+	.title {
+	border-width: 1px 1px 0;
+	border-style: solid;
+	font-size: var(--sl-text-sm);
+	background: transparent;
+	border-radius: 0;
+	border-color: var(--sl-color-border) var(--sl-color-border) transparent;
+}
+.sl-markdown-content
+	.expressive-code
+	.frame.has-title:not(.is-terminal)
+	.title:after {
+	border: none;
+}
+.sl-markdown-content .expressive-code .frame pre {
+	background: transparent;
+}
+.sl-markdown-content .expressive-code .frame.has-title pre {
+	border-color: var(--sl-color-border);
+}
+/* Terminal */
+.sl-markdown-content .expressive-code .frame.is-terminal .header {
+	font-size: var(--sl-text-sm);
+	font-weight: normal;
+	border-radius: 0;
+	background: transparent;
+	border-color: var(--sl-color-border);
+}
+.sl-markdown-content .expressive-code .frame.is-terminal .header:after {
+	border-color: var(--sl-color-border);
+}
+.sl-markdown-content .expressive-code .frame.is-terminal pre {
+	border-color: var(--sl-color-border);
+}
+/* Code markers */
+:root[data-theme="light"] .expressive-code .frame,
+.expressive-code[data-theme="light"] .frame {
+	--ec-tm-markBg: #00000011;
+	--ec-tm-insBg: #90c87e72;
+	--ec-tm-delBg: #ff9c8f7f;
+}
+:root[data-theme="dark"] .expressive-code .frame,
+.expressive-code[data-theme="dark"] .frame {
+	--ec-tm-markBg: #ffffff0f;
+	--ec-tm-insBg: #1e561572;
+	--ec-tm-delBg: #862d2766;
+}
+.sl-markdown-content .expressive-code .ec-line.mark > .code,
+.sl-markdown-content .expressive-code .ec-line.ins > .code,
+.sl-markdown-content .expressive-code .ec-line.del > .code {
+	border-inline-start-color: transparent;
+}
+.sl-markdown-content .expressive-code .ec-line mark:before,
+.sl-markdown-content .expressive-code .ec-line ins:before,
+.sl-markdown-content .expressive-code .ec-line del:before {
+	border-width: 0px;
+}
+
+/**
+ * Tabs
+ */
+.sl-markdown-content [role="tablist"] {
+	border-color: var(--sl-color-hairline);
+}
+.sl-markdown-content .tab > [role="tab"] {
+	font-weight: 600;
+	color: var(--sl-color-text-dimmed);
+	border-color: var(--sl-color-hairline);
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	font-size: var(--sl-text-code-sm);
+	padding-block-end: 0.375rem;
+}
+.sl-markdown-content .tab > [role="tab"][aria-selected="true"] {
+	color: var(--sl-color-text);
+	border-color: var(--sl-color-border);
+}
+
+/**
+ * Tables
+ */
+.sl-markdown-content thead th:not(:where(.not-content *)) {
+	border-bottom: 1px solid var(--sl-color-border);
+}
+.sl-markdown-content :is(th):not(:where(.not-content *)) {
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	font-size: var(--sl-text-code-sm);
+	text-align: left;
+	padding-block-start: 0;
+}
+.sl-markdown-content tbody > tr td:not(:where(.not-content *)) {
+	font-size: var(--sl-text-sm);
+	border-bottom: 1px solid var(--sl-color-hairline);
+}
+.sl-markdown-content :is(td):not(:where(.not-content *)) {
+	padding-block: 0.5rem;
+	border: none;
+}
+.sl-markdown-content tr:nth-child(2n):not(:where(.not-content *)) {
+	background-color: transparent;
+}
+
+/**
+ * Asides
+ */
+.starlight-aside {
+	border: none;
+	border-radius: 0;
+	padding: 0.9375rem 1rem 0.875rem;
+}
+.starlight-aside__title {
+	text-transform: uppercase;
+	font-size: var(--sl-text-code-sm);
+	font-weight: 700;
+	letter-spacing: 0.5px;
+	gap: 0.4rem;
+}
+.starlight-aside__icon {
+	font-size: 0.875rem;
+	width: 0.8125rem;
+	height: 0.8125rem;
+	opacity: 0.9;
+}
+.starlight-aside__title + .starlight-aside__content {
+	margin-top: 0.75rem;
+	font-size: var(--sl-text-sm);
+}
+.sl-markdown-content
+	.starlight-aside__content
+	code:not(:where(.not-content *)) {
+	background-color: transparent;
+	font-size: var(--sl-text-xs);
+}
+.custom-aside-video .starlight-aside__title {
+	font-weight: normal;
+	font-size: var(--sl-text-sm);
+	text-transform: none;
+	letter-spacing: 0;
+	line-height: normal;
+	gap: 0.5rem;
+}
+.custom-aside-video .starlight-aside__title a {
+	text-decoration: none;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+.custom-aside-video .starlight-aside__title a:hover {
+	text-decoration: underline;
+}
+.custom-aside-video .starlight-aside__title a svg {
+	opacity: 0.8;
+}
+
+/**
+* Lists
+*/
+.sl-markdown-content li:not(:where(.not-content *)) > ol,
+.sl-markdown-content li:not(:where(.not-content *)) > ul,
+.sl-markdown-content li + li:not(:where(.not-content *)) {
+  margin-top: 0.625rem;
+}
+.sl-markdown-content li > :last-child:not(li, ul, ol):not(a, strong, em, del, span, input, :where(.not-content *)) {
+  margin-bottom: calc(var(--paragraph-spacing) + 0.5rem);
+}
+
+/**
+* Details
+*/
+.sl-markdown-content details:not(:where(.not-content *)) {
+	--sl-details-border-color--hover: var(--sl-details-border-color);
+}

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/styles/theme.css
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/styles/theme.css
@@ -1,0 +1,324 @@
+:root {
+	--__sl-font: "IBM Plex Mono", var(--sl-font-system-mono);
+
+	--sl-line-height: 1.6875;
+
+  --sl-color-text: var(--sl-color-white);
+
+	--sl-text-2xs: 0.75rem; /* 12px */
+	--sl-text-xs: 0.8125rem; /* 13px */
+	--sl-text-sm: 0.875rem; /* 14px */
+	--sl-text-base: 1rem; /* 16px */
+	--sl-text-lg: 1.125rem; /* 18px */
+	--sl-text-xl: 1.25rem; /* 20px */
+	--sl-text-2xl: 1.375rem; /* 22px */
+	--sl-text-3xl: 1.5625rem; /* 25px */
+	--sl-text-4xl: 1.875rem; /* 30px */
+	--sl-text-5xl: 2.5rem; /* 40px */
+	--sl-text-6xl: 3.25rem; /* 52px */
+
+	--sl-text-h1: 2rem;
+	--sl-text-h2: var(--sl-text-4xl);
+	--sl-text-h3: 1.5rem;
+	--sl-text-h4: var(--sl-text-xl);
+	--sl-text-h5: var(--sl-text-lg);
+
+	--paragraph-spacing: 1.375rem;
+}
+
+@media (min-width: 50rem) {
+	:root {
+		--sl-text-h1: 2.5rem;
+		--sl-text-h2: 2rem;
+		--sl-text-h3: 1.5625rem;
+		--sl-text-h4: 1.25rem;
+	}
+}
+
+/* Dark mode */
+:root,
+::backdrop {
+	--sl-color-border: var(--sl-color-gray-4);
+
+	--sl-color-text-secondary: hsl(224, 6%, 66%);
+	--sl-color-text-dimmed: hsl(224, 7%, 46%);
+}
+/* Light mode */
+:root[data-theme="light"],
+[data-theme="light"] ::backdrop {
+	--sl-color-border: var(--sl-color-gray-5);
+
+	--sl-color-text-secondary: hsl(224, 7%, 46%);
+	--sl-color-text-dimmed: hsl(224, 6%, 63%);
+}
+
+body {
+	text-underline-offset: 0.1875rem;
+}
+
+a {
+	color: var(--sl-color-text);
+}
+
+/**
+ * Header
+ */
+body > .page > header {
+	background-color: var(--sl-color-black);
+	border-color: var(--sl-color-border);
+}
+@media (min-width: 50rem) {
+	body > .page > header,
+	:root[data-has-sidebar] body > .page > header {
+		padding-inline-start: var(--sl-nav-pad-y);
+		padding-inline-end: var(--sl-nav-pad-y);
+	}
+}
+body > .page > header a.site-title img {
+	height: 1.5rem;
+}
+@media (max-width: 30rem) {
+	body > .page > header a.site-title img {
+		height: 1.625rem;
+	}
+}
+/* Search button */
+body > .page > header button[data-open-modal] {
+	border-radius: 0;
+	border: none;
+	height: 2.25rem;
+	padding: 0 0 0 0.5rem;
+	color: var(--sl-color-text-secondary);
+	gap: 0.4375rem;
+	background-color: transparent;
+	line-height: normal;
+	text-transform: uppercase;
+}
+body > .page > header button[data-open-modal] span {
+	text-decoration: underline;
+}
+body > .page > header button[data-open-modal] svg {
+	display: none;
+}
+body > .page > header button[data-open-modal] > kbd {
+	background-color: transparent;
+	padding-inline-start: 0;
+	padding-inline-end: 0;
+	letter-spacing: -1px;
+}
+body > .page > header button[data-open-modal] > kbd kbd {
+	line-height: 1;
+	color: var(--sl-color-text-dimmed);
+}
+/* Mobile nav button */
+body > .page > nav starlight-menu-button button {
+	background-color: transparent;
+	color: var(--color-text);
+	box-shadow: none;
+}
+[data-theme="light"] starlight-menu-button[aria-expanded="true"] button {
+	background-color: var(--sl-color-gray-6);
+}
+[data-theme="dark"] starlight-menu-button[aria-expanded="true"] button {
+	background-color: var(--sl-color-gray-6);
+}
+starlight-theme-select {
+	display: none;
+}
+
+/**
+ * Content
+ */
+body > .page > .main-frame .main-pane > main > .content-panel + .content-panel {
+	border-top: 1px solid var(--sl-color-border);
+}
+@media (min-width: 72rem) {
+	body > .page > .main-frame .main-pane > main > .content-panel .sl-container {
+		margin-inline: auto;
+	}
+}
+
+/**
+ * Sidebar
+ */
+nav.sidebar .sidebar-pane {
+	border-color: var(--sl-color-border);
+	padding-top: 0;
+	background-color: var(--sl-color-bg);
+}
+nav.sidebar .sidebar-pane > .sidebar-content {
+	scrollbar-width: thin;
+}
+nav.sidebar .sidebar-pane > .sidebar-content::-webkit-scrollbar {
+	display: none;
+}
+nav.sidebar ul > li {
+	border-inline-start: none;
+}
+nav.sidebar ul.top-level > li > a,
+nav.sidebar ul.top-level > li > details > summary,
+nav.sidebar ul.top-level > li > details > ul > li {
+	padding-inline-start: 0;
+	margin-inline-start: 0;
+}
+nav.sidebar ul > li + li {
+	margin-top: 0.25rem;
+}
+nav.sidebar ul.top-level > li + li:has(> details) {
+	margin-top: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+nav.sidebar summary {
+	padding-bottom: 0;
+	margin-bottom: 0.5rem;
+}
+nav.sidebar a {
+	font-size: var(--sl-text-sm);
+}
+nav.sidebar a,
+nav.sidebar span.large {
+	font-size: var(--sl-text-sm);
+	font-weight: 400;
+	color: var(--sl-color-gray-2);
+}
+nav.sidebar ul.top-level > li > details > summary .group-label > span {
+	font-weight: 600;
+	text-transform: uppercase;
+	font-family: var(--__sl-font-mono);
+	font-size: var(--sl-text-code-sm);
+	letter-spacing: 0.5px;
+	color: var(--sl-color-gray-2);
+}
+nav.sidebar summary svg.caret {
+	color: var(--sl-color-text-dimmed);
+}
+nav.sidebar a:hover {
+	color: var(--sl-color-text);
+}
+nav.sidebar a[aria-current="page"],
+nav.sidebar a[aria-current="page"]:hover,
+nav.sidebar a[aria-current="page"]:focus {
+	font-weight: 600;
+	color: var(--sl-color-text);
+	background-color: transparent;
+}
+
+/**
+ * Right sidebar
+ */
+@media (min-width: 72rem) {
+	.right-sidebar {
+		border-color: var(--sl-color-border);
+	}
+}
+.right-sidebar-panel h2 {
+	/* Margin to align with main sidebar */
+	margin-top: 0.3125rem;
+	font-weight: 600;
+	color: var(--color-text-dimmed);
+	text-transform: uppercase;
+	font-size: var(--sl-text-code-sm);
+	line-height: 1.4;
+	letter-spacing: -0.5px;
+}
+
+.right-sidebar-panel a {
+	--pad-inline: 0px;
+}
+.right-sidebar-panel a {
+	color: var(--sl-color-text-dimmed);
+}
+.right-sidebar-panel a:hover {
+	color: var(--sl-color-text-dimmed);
+}
+.right-sidebar-panel a[aria-current="true"],
+.right-sidebar-panel a[aria-current="true"]:hover,
+.right-sidebar-panel a[aria-current="true"]:focus {
+	font-weight: 500;
+	background-color: transparent;
+	color: var(--sl-color-text);
+}
+.right-sidebar-panel ul li > a {
+	padding-inline: calc(0.75rem * var(--depth) + var(--pad-inline))
+		var(--pad-inline);
+}
+/* Mobile nav */
+mobile-starlight-toc nav {
+	backdrop-filter: blur(8px);
+	-webkit-backdrop-filter: blur(8px);
+	border-top: none;
+	background-color: var(--sl-color-bg);
+}
+mobile-starlight-toc nav summary {
+	gap: 0.75rem;
+	border-bottom: 1px solid var(--sl-color-border);
+}
+mobile-starlight-toc nav summary .toggle {
+	border-radius: var(--border-radius);
+	height: 2rem;
+	background-color: transparent;
+	color: var(--color-text);
+	border: none;
+	text-decoration: underline;
+}
+mobile-starlight-toc nav summary .toggle:hover {
+	color: var(--sl-color-text);
+}
+mobile-starlight-toc nav summary .toggle svg {
+	color: var(--sl-color-text-dimmed);
+}
+mobile-starlight-toc nav .dropdown {
+	border: none;
+	background-color: transparent;
+	border-bottom: 1px solid var(--sl-color-hairline);
+}
+mobile-starlight-toc nav .dropdown a {
+	border-color: var(--sl-color-hairline);
+}
+mobile-starlight-toc nav .dropdown a[aria-current="true"] {
+	font-weight: 500;
+}
+mobile-starlight-toc nav .dropdown a[aria-current="true"]::after {
+	background-color: var(--sl-color-text-dimmed);
+}
+
+/**
+ * Search dialog
+ */
+dialog[aria-label="Search"] {
+	border: none;
+	border-radius: 0;
+	border: 1px solid var(--sl-color-border);
+	background-color: var(--sl-color-bg);
+	box-shadow: var(--sl-shadow-md);
+}
+dialog[aria-label="Search"][open] {
+	animation: fadeInScaleUp 0.2s ease forwards;
+}
+dialog[aria-label="Search"]::backdrop {
+	backdrop-filter: blur(2px);
+	-webkit-backdrop-filter: blur(2px);
+	animation: fadeInBackdrop 0.2s ease forwards;
+}
+/* @media (prefers-color-scheme: light) { */
+/*   dialog[aria-label='Search']::backdrop { */
+/*   } */
+/* } */
+@keyframes fadeInScaleUp {
+	from {
+		opacity: 0;
+		transform: scale(0.9);
+	}
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+@keyframes fadeInBackdrop {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/packages/gal-code/packages/web/src/vendor/docs-theme/styles/tsdoc.css
+++ b/packages/gal-code/packages/web/src/vendor/docs-theme/styles/tsdoc.css
@@ -1,0 +1,80 @@
+/**
+ * Segments
+ */
+.sl-markdown-content > .tsdoc div.segment:not(:last-child):after {
+	content: "";
+	display: block;
+	height: 1px;
+	background: var(--sl-color-hairline);
+	margin-top: 1rem;
+}
+
+/**
+ * Headings
+ */
+.sl-markdown-content > .tsdoc section h4:not(:where(.not-content *)) {
+	font-size: var(--sl-text-h5);
+}
+.sl-markdown-content
+	> .tsdoc
+	section.inline
+	p:first-child
+	strong:not(:where(.not-content *)) {
+	margin-right: var(--tsdoc-key-margin-right);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--sl-color-text);
+}
+
+/**
+ * Nested Title
+ */
+.sl-markdown-content > .tsdoc :is(h4, h5).nested a {
+	text-decoration: none;
+}
+.sl-markdown-content > .tsdoc :is(h4, h5).nested span.parent {
+	font-weight: 400;
+	color: var(--sl-color-text-secondary);
+}
+.sl-markdown-content > .tsdoc h4.nested span.parent {
+	font-size: calc(var(--sl-text-h4) - 0.0625rem);
+}
+
+/**
+ * Keys & Values
+ */
+.sl-markdown-content > .tsdoc section code.key:before,
+.sl-markdown-content > .tsdoc section code.type:before,
+.sl-markdown-content > .tsdoc section code.method:before,
+.sl-markdown-content > .tsdoc section code.symbol:before,
+.sl-markdown-content > .tsdoc section code.primitive:before,
+.sl-markdown-content > .tsdoc section code.key:after,
+.sl-markdown-content > .tsdoc section code.type:after,
+.sl-markdown-content > .tsdoc section code.method:after,
+.sl-markdown-content > .tsdoc section code.symbol:after,
+.sl-markdown-content > .tsdoc section code.primitive:after {
+	content: "";
+}
+.sl-markdown-content > .tsdoc section code.key {
+	margin-right: var(--tsdoc-key-margin-right);
+}
+.sl-markdown-content > .tsdoc section code.key,
+.sl-markdown-content > .tsdoc section code.primitive {
+	color: var(--sl-color-text);
+}
+.sl-markdown-content > .tsdoc section code.symbol {
+	color: var(--sl-color-text-secondary);
+}
+.sl-markdown-content > .tsdoc section code.type,
+.sl-markdown-content > .tsdoc section code.symbol,
+.sl-markdown-content > .tsdoc section code.primitive {
+	font-weight: 400;
+}
+.sl-markdown-content > .tsdoc section code.primitive {
+	font-style: italic;
+}
+
+.sl-markdown-content > .tsdoc section span.dimmed {
+	color: var(--sl-color-text-secondary);
+}


### PR DESCRIPTION
Addresses #423.

## Why
`toolbeam-docs-theme@0.4.8` (the docs site's Starlight theme) is **unmaintained** and pinned to `@astrojs/starlight ^0.34.3` — it is the **root-cause blocker for every future Starlight/astro upgrade** (it's exactly why astro 6 is blocked). This removes the dependency by absorbing what the site actually uses into the repo, so the site **owns its theme** and upgrades are unblocked.

## What
The site's dependency was narrow — only `astro.config.mjs` (the `theme({headerLinks})` plugin) and `Header.astro` (renders the theme's `overrides/Header.astro`); the docs content never used the theme's content components. So:

- **Vendored** under `packages/web/src/vendor/docs-theme/` (MIT `LICENSE` + a `README` documenting provenance): the 4 stylesheets (`theme/tsdoc/markdown/headings.css`), the `Header` + `PageTitle` overrides, and the `HeaderLinks` component.
- The plugin's effects are now **plain Starlight config** in `astro.config.mjs`: IBM Plex Mono fonts + the 4 theme CSS prepended to `customCss` (**order preserved** so the cascade is unchanged), `PageTitle` added to `components`, and `pagination: false`.
- `HeaderLinks.astro` now reads `config.headerLinks` directly (was the plugin's `globalThis`).
- `Header.astro` imports the vendored override; `toolbeam-docs-theme` removed from `package.json` + `bun.lock`.

Net diff: a few config edits + the vendored files (mostly CSS). Fully reversible, on the current known-good astro 5.18.2.

## Validated locally
`astro build` exit 0 → **631 static HTML** still built; IBM Plex Mono + theme CSS confirmed bundled; **typecheck 13/13**; **zero** real `toolbeam-docs-theme` references remain (only explanatory comments).

## ⚠️ Required before merge — preview deploy (visual parity)
This is a public site and the win is *visual* equivalence, so local build-success isn't enough. Land on `dev` (→ `bun sst deploy` → **`docs.dev.gal.run`**) and confirm the header (logo, nav links, social icons, search, locale), **page titles** (the PageTitle override), **fonts** (IBM Plex Mono in code blocks), and markdown/code styling look identical to live `docs.gal.run`.

## Coordinates with the other open web PR
Stacks cleanly with **#460** (docs → static). Both touch `astro.config.mjs` but different sections (`output` vs `customCss`/`components`/plugin) and different components (`Head` vs `Header`) — small/mechanical rebase if #460 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
