### PR TITLE
mcp/computer-use: rescue vendored skills (companion-clis, flash, runpodctl) [ci]

### DIFF
--- a/mcp/computer-use/.agents/skills/companion-clis/SKILL.md
+++ b/mcp/computer-use/.agents/skills/companion-clis/SKILL.md
@@ -1,0 +1,422 @@
+---
+name: companion-clis
+description: Companion CLIs for Runpod workflows — HuggingFace, GitHub, Docker, and AWS.
+allowed-tools: Bash(hf:*), Bash(gh:*), Bash(docker:*), Bash(aws:*), Bash(ssh-keygen:*), Bash(ssh-add:*), Bash(ssh-agent:*)
+compatibility: Linux, macOS, Windows
+metadata:
+  author: runpod
+  version: "1.0"
+license: Apache-2.0
+---
+
+# Companion CLIs
+
+Four CLIs commonly needed alongside Runpod: HuggingFace (`hf`), GitHub (`gh`), Docker (`docker`), and AWS (`aws`). Each requires credentials before use.
+
+## Windows: Install WSL2 First
+
+If you are on Windows, install WSL2 (Windows Subsystem for Linux) before proceeding. WSL2 gives you a native Linux environment on Windows, which all these CLIs are designed for. Run in PowerShell as Administrator, then restart:
+
+```powershell
+wsl --install
+```
+
+This installs WSL2 with Ubuntu by default. After restarting, open the Ubuntu app to complete setup (create a Linux username and password). From that point on, follow the **Linux** instructions throughout this skill.
+
+## HuggingFace CLI
+
+The HuggingFace CLI (`hf`) is used to download models from the Hub to your local machine so they are cached and available when you build and run the Docker container. For example, to deploy `meta-llama/Llama-3.1-8B` to a Runpod serverless endpoint: download the model locally first, build a Docker image that includes or mounts it, validate the container locally, then push the image to Docker Hub for Runpod to pull.
+
+### Install
+
+```bash
+# macOS / Linux (standalone installer — recommended)
+curl -LsSf https://hf.co/cli/install.sh | bash
+
+# macOS (Homebrew)
+brew install hf
+
+# Windows (WSL2): use the Linux standalone installer above
+```
+
+> **Note:** `pip install huggingface_hub` installs the older Python CLI (`huggingface-cli`), which uses different command syntax. The commands below are for the standalone `hf` CLI.
+
+### Credentials
+
+Get a token at https://huggingface.co/settings/tokens. Use **write** access for uploading; **read** access is sufficient for downloading public or gated models.
+
+```bash
+# Option 1: interactive login (saves token to ~/.cache/huggingface/token, optionally to git credential store)
+hf auth login
+
+# Option 2: non-interactive (pass token directly, useful in scripts and pod start commands)
+hf auth login --token $HF_TOKEN --add-to-git-credential
+
+# Option 3: environment variable (takes precedence over saved token; to revert, unset the variable)
+export HF_TOKEN=hf_...
+```
+
+```bash
+hf auth whoami      # confirm auth and org memberships
+hf auth logout      # delete all locally stored tokens
+```
+
+### Key Commands
+
+```bash
+# Download a model to a local directory (use --local-dir to control where it lands)
+hf download meta-llama/Llama-3.1-8B --local-dir ./models/llama-3.1-8b
+hf download TinyLlama/TinyLlama-1.1B-Chat-v1.0 --local-dir ./models/tinyllama
+
+# Download a single file from a model repo
+hf download meta-llama/Llama-3.1-8B config.json --local-dir ./models/llama-3.1-8b
+
+# Download with glob filters (e.g. only safetensors weights, skip fp16 variants)
+hf download stabilityai/stable-diffusion-xl-base-1.0 \
+  --include "*.safetensors" --exclude "*.fp16.*" \
+  --local-dir ./models/sdxl
+
+# Download a specific revision (commit hash, branch, or tag — append --revision REF)
+hf download meta-llama/Llama-3.1-8B --revision v1.0 --local-dir ./models/llama-3.1-8b
+```
+
+### Troubleshooting
+
+```bash
+# Increase download timeout on slow connections (default: 10s)
+export HF_HUB_DOWNLOAD_TIMEOUT=30
+```
+
+---
+
+## GitHub CLI
+
+The GitHub CLI (`gh`) is used to manage repositories for Runpod serverless workers. This includes cloning repos into local Docker containers for testing, versioning source code so changes can be tracked and shared with teammates or collaborators, and creating GitHub releases that publish listings to the Runpod Hub. The Hub indexes releases — not commits — so every deployment update requires a new release.
+
+### Install
+
+```bash
+# macOS
+brew install gh
+
+# Linux (Debian/Ubuntu)
+(type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
+  && sudo mkdir -p -m 755 /etc/apt/keyrings \
+  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+     | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt update && sudo apt install gh -y
+
+# Linux (Alpine)
+apk add github-cli
+
+# Windows (WSL2): use the Linux (Debian/Ubuntu) installer above
+```
+
+### SSH Keys
+
+An SSH key identifies your machine as authentic to remote services. Generate one key and register the public key with each service that requires it — GitHub (via `gh`) and HuggingFace (via browser).
+
+**Generate a key**
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+# Saves to ~/.ssh/id_ed25519 (private) and ~/.ssh/id_ed25519.pub (public)
+# Press Enter to accept the default path; set a passphrase or leave blank
+```
+
+**Add the key to the SSH agent**
+
+```bash
+# macOS
+eval "$(ssh-agent -s)"
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+
+# macOS — also add to ~/.ssh/config so the key loads automatically on login.
+# Create the file if it doesn't exist, and add these lines:
+#
+#   Host *
+#     AddKeysToAgent yes
+#     UseKeychain yes
+#     IdentityFile ~/.ssh/id_ed25519
+
+# Linux
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+
+# Windows (WSL2): use the Linux instructions above
+```
+
+### Credentials
+
+```bash
+# Interactive login — when prompted, select SSH as the git protocol
+gh auth login
+
+# Verify auth
+gh auth status
+```
+
+**Register the public key with each service**
+
+```bash
+# GitHub — upload via gh CLI (requires auth above to be completed first)
+gh ssh-key add ~/.ssh/id_ed25519.pub --title "my-machine"
+
+# HuggingFace — paste contents of public key manually in browser
+cat ~/.ssh/id_ed25519.pub   # copy this output
+# Then add at https://huggingface.co/settings/keys
+```
+
+### Key Commands
+
+```bash
+# Repositories
+gh repo create my-worker --public             # create a new public repo (required for Hub)
+gh repo clone owner/repo                      # clone a repository over SSH
+gh repo clone owner/repo -- --depth 1        # shallow clone
+gh repo view owner/repo                       # view repo details and URL
+
+# Releases — the Runpod Hub indexes releases, not commits
+# Every update to a Hub listing requires a new GitHub release
+gh release create v1.0.0 --title "v1.0.0" --notes "Initial release"   # create a release
+gh release create v1.0.1 --title "v1.0.1" --notes "Update model tag"  # update Hub listing
+gh release list                               # list all releases
+gh release view v1.0.0                        # view release details
+```
+
+#### Runpod Hub repository structure
+
+A Hub-compatible repository requires these files (in root or `.runpod/` directory):
+
+```
+handler.py        # serverless worker implementation
+Dockerfile        # container definition
+README.md         # documentation shown on Hub listing
+.runpod/
+  hub.json        # Hub metadata: title, description, category, GPU config, env vars
+  tests.json      # test cases run after each release
+```
+
+To publish: go to https://console.runpod.io → Hub → Add your repo → enter the GitHub repository URL.
+
+---
+
+## Docker
+
+Docker is used to build and validate container images locally before pushing to Docker Hub. Runpod uses Docker Hub as its default image registry — serverless endpoints, pods, and templates all reference images by their Docker Hub tag. Once an image is pushed, Runpod workers pull it automatically when the endpoint or pod is started.
+
+### Install
+
+**macOS:** Download Docker Desktop from https://docs.docker.com/desktop/setup/install/mac-install/
+- Choose the **Apple Silicon** installer for M-series Macs, or **Intel Chip** for older Macs
+- Open the DMG, drag Docker to Applications, and launch it
+
+**Windows:** Download Docker Desktop from https://docs.docker.com/desktop/setup/install/windows-install/
+- Requires WSL 2 — if you followed the WSL2 setup above, Docker Desktop will detect it automatically
+- After installation, `docker` commands work inside your WSL2 terminal without extra configuration
+- Run the installer and follow the setup wizard
+
+**Linux:** See https://docs.docker.com/engine/install/ for distro-specific instructions
+
+```bash
+# Linux convenience script (Ubuntu/Debian)
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER   # allow non-root usage (re-login after)
+```
+
+### Credentials
+
+Docker Hub authentication uses a personal access token (PAT), not your account password.
+
+1. Go to https://app.docker.com → Avatar (top right) → Account Settings → Personal Access Tokens
+2. Click **Generate new token** — give it a descriptive name, set an expiration, and choose **Read & Write** access
+3. Copy the token immediately — it is shown only once
+
+```bash
+docker login -u DOCKERHUB_USERNAME
+# When prompted for a password, paste your personal access token
+```
+
+Credentials are saved to `~/.docker/config.json` after a successful login.
+
+### Tagging
+
+> **Always use explicit semantic version tags. Never rely on `latest`.**
+
+The `latest` tag does not automatically point to the newest image — it only reflects the last build that was pushed without an explicit tag. If you push `v1.0.0` and then push `v1.0.1` with an explicit tag, `latest` still points to `v1.0.0`. Runpod workers pinned to `latest` will silently pull the wrong version.
+
+Use a tag that uniquely identifies the build: `v1.0.0`, `v1.0.1`, etc.
+
+```bash
+# Correct: explicit semantic version tag
+docker build --platform=linux/amd64 -t myorg/myimage:v1.0.0 .
+docker push myorg/myimage:v1.0.0
+
+# Wrong: latest tag is ambiguous and unreliable
+docker build -t myorg/myimage:latest .
+```
+
+### Docker Hub
+
+Docker Hub is the registry Runpod pulls images from. After pushing, images are visible at https://hub.docker.com/repositories/ and referenceable in Runpod as `username/image:tag`.
+
+Images on Docker Hub can be public (anyone can pull) or private (requires credentials). For private images, register your Docker Hub credentials in Runpod once and they become available to any template:
+
+1. Go to https://console.runpod.io/user/settings → **Container Registry Settings**
+2. Add your Docker Hub username and personal access token (the same PAT used for `docker login`)
+3. When creating or editing a template, select the saved credential from the dropdown
+
+> Runpod currently only supports `docker login` type credentials for container registry authentication.
+
+### Key Commands
+
+```bash
+# Build for Runpod (always --platform=linux/amd64 — pods run on x86 Linux)
+docker build --platform=linux/amd64 -t myorg/myimage:v1.0.0 .
+docker build --platform=linux/amd64 -t myorg/myimage:v1.0.0 -f Dockerfile.prod .  # specify Dockerfile
+
+# Tag an existing image before pushing (does not duplicate image data)
+docker tag myorg/myimage:v1.0.0 myorg/myimage:v1.0.1
+
+# Push to Docker Hub (image becomes available to Runpod as myorg/myimage:v1.0.0)
+docker push myorg/myimage:v1.0.0
+
+# Run locally for validation
+docker run --rm -it myorg/myimage:v1.0.0 bash
+docker run --rm --gpus all myorg/myimage:v1.0.0 bash   # with GPU (requires nvidia-container-toolkit)
+docker run --rm -p 8080:80 -e API_KEY=secret myorg/myimage:v1.0.0  # port mapping + env vars
+
+# Debug a running container
+docker exec -it CONTAINER_ID /bin/bash
+
+# Inspect
+docker images                          # list local images
+docker ps -a                           # list all containers (including stopped)
+docker logs CONTAINER_ID             # view container output
+docker logs -f CONTAINER_ID          # follow logs in real time
+
+# Cleanup
+docker rmi myorg/myimage:v1.0.0        # remove an image
+docker rm CONTAINER_ID               # remove a stopped container
+```
+
+---
+
+## AWS CLI
+
+The AWS CLI is used to access Runpod storage over the S3 protocol. Any Runpod product that can mount a Network Volume — pods, clusters, and serverless endpoints — can have its storage accessed this way. The bucket name is the network volume ID.
+
+### Install
+
+```bash
+# macOS
+brew install awscli
+
+# Linux
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip
+unzip awscliv2.zip && sudo ./aws/install
+```
+
+### Credentials
+
+Runpod uses its own S3-compatible API, not AWS. You need a Runpod user ID and S3 API key — not an AWS account.
+
+- **Access key** (`AWS_ACCESS_KEY_ID`): your Runpod user ID — found in the console under Settings > S3 API Keys, in the key description (format: `user_...`)
+- **Secret key** (`AWS_SECRET_ACCESS_KEY`): an S3 API key — generate one at Settings > S3 API Keys > Create. Shown only once; save it immediately (format: `rps_...`)
+
+```bash
+# Option 1: interactive configure (writes ~/.aws/credentials and ~/.aws/config)
+# When prompted: enter user ID as access key, S3 API key as secret.
+# Press Enter to skip region and output format — region is always passed per-command, not stored in config.
+aws configure
+
+aws configure list    # verify stored credentials
+
+# Option 2: environment variables (override config files)
+export AWS_ACCESS_KEY_ID=user_...
+export AWS_SECRET_ACCESS_KEY=rps_...
+
+# To stop using env vars and fall back to config file:
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+```
+
+### Region and Endpoint
+
+The `--region` flag on every command is the Runpod datacenter ID where the network volume lives — not an AWS region. The `--endpoint-url` is derived from the same datacenter ID.
+
+Every command requires both flags:
+```
+--region DATACENTER --endpoint-url https://s3api-DATACENTER.runpod.io/
+```
+
+**Tip:** Each network volume on the storage page at https://console.runpod.io/user/storage/ shows a pre-filled example `aws s3 ls` command with the correct `--region` and `--endpoint-url` already substituted. Use this to confirm the exact values for a given volume.
+
+Datacenter IDs by region:
+
+| Region | Datacenter IDs |
+|--------|---------------|
+| EU | CZ-1, RO-1, IS-1, NO-1 |
+| US | CA-2, GA-2, IL-1, KS-2, MD-1, MO-1, MO-2, NC-1, NC-2, NE-1, WA-1 |
+
+### Key Commands
+
+Replace `DATACENTER` with the datacenter ID of your network volume (e.g. `CA-2`) and `NETWORK_VOLUME_ID` with the volume ID (used as the S3 bucket name).
+
+```bash
+# List files in a volume
+aws s3 ls \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/
+
+# List a subdirectory
+aws s3 ls \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/my-folder/
+
+# Upload a file
+aws s3 cp local-file.txt \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/
+
+# Download a file
+aws s3 cp \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/remote-file.txt ./
+
+# Delete a file
+aws s3 rm \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/remote-file.txt
+
+# Sync a local directory to a volume
+aws s3 sync local-dir/ \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  s3://NETWORK_VOLUME_ID/remote-dir/
+```
+
+Path mapping: `/workspace/my-folder/file.txt` on a pod = `s3://NETWORK_VOLUME_ID/my-folder/file.txt` via S3.
+
+### Troubleshooting
+
+```bash
+# Retry on timeout (large transfers)
+export AWS_RETRY_MODE=standard
+export AWS_MAX_ATTEMPTS=10
+
+# Extend read timeout for large files (seconds)
+aws s3 cp large-file.zip \
+  --region DATACENTER \
+  --endpoint-url https://s3api-DATACENTER.runpod.io/ \
+  --cli-read-timeout 7200 \
+  s3://NETWORK_VOLUME_ID/
+```

--- a/mcp/computer-use/.agents/skills/flash/SKILL.md
+++ b/mcp/computer-use/.agents/skills/flash/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: flash
+description: runpod-flash SDK and CLI for deploying AI workloads on Runpod serverless GPUs/CPUs.
+user-invocable: true
+---
+
+# Runpod Flash
+
+Write code locally, test with `flash run` (dev server at localhost:8888), and flash automatically provisions and deploys to remote GPUs/CPUs in the cloud. `Endpoint` handles everything.
+
+## Setup
+
+```bash
+pip install runpod-flash                 # requires Python >=3.10
+
+# auth option 1: browser-based login (saves token locally)
+flash login
+
+# auth option 2: API key via environment variable
+export RUNPOD_API_KEY=your_key
+
+flash init my-project                    # scaffold a new project in ./my-project
+```
+
+## CLI
+
+```bash
+flash run                                # start local dev server at localhost:8888
+flash run --auto-provision               # same, but pre-provision endpoints (no cold start)
+flash build                              # package artifact for deployment (500MB limit)
+flash build --exclude pkg1,pkg2          # exclude packages from build
+flash deploy                             # build + deploy (auto-selects env if only one)
+flash deploy --env staging               # build + deploy to "staging" environment
+flash deploy --app my-app --env prod     # deploy a specific app to an environment
+flash deploy --preview                   # build + launch local preview in Docker
+flash env list                           # list deployment environments
+flash env create staging                 # create "staging" environment
+flash env get staging                    # show environment details + resources
+flash env delete staging                 # delete environment + tear down resources
+flash undeploy list                      # list all active endpoints
+flash undeploy my-endpoint               # remove a specific endpoint
+```
+
+## Endpoint: Three Modes
+
+### Mode 1: Your Code (Queue-Based Decorator)
+
+One function = one endpoint with its own workers.
+
+```python
+from runpod_flash import Endpoint, GpuGroup
+
+@Endpoint(name="my-worker", gpu=GpuGroup.AMPERE_80, workers=5, dependencies=["torch"])
+async def compute(data):
+    import torch  # MUST import inside function (cloudpickle)
+    return {"sum": torch.tensor(data, device="cuda").sum().item()}
+
+result = await compute([1, 2, 3])
+```
+
+### Mode 2: Your Code (Load-Balanced Routes)
+
+Multiple HTTP routes share one pool of workers.
+
+```python
+from runpod_flash import Endpoint, GpuGroup
+
+api = Endpoint(name="my-api", gpu=GpuGroup.ADA_24, workers=(1, 5), dependencies=["torch"])
+
+@api.post("/predict")
+async def predict(data: list[float]):
+    import torch
+    return {"result": torch.tensor(data, device="cuda").sum().item()}
+
+@api.get("/health")
+async def health():
+    return {"status": "ok"}
+```
+
+### Mode 3: External Image (Client)
+
+Deploy a pre-built Docker image and call it via HTTP.
+
+```python
+from runpod_flash import Endpoint, GpuGroup, PodTemplate
+
+server = Endpoint(
+    name="my-server",
+    image="my-org/my-image:latest",
+    gpu=GpuGroup.AMPERE_80,
+    workers=1,
+    env={"HF_TOKEN": "xxx"},
+    template=PodTemplate(containerDiskInGb=100),
+)
+
+# LB-style
+result = await server.post("/v1/completions", {"prompt": "hello"})
+models = await server.get("/v1/models")
+
+# QB-style
+job = await server.run({"prompt": "hello"})
+await job.wait()
+print(job.output)
+```
+
+Connect to an existing endpoint by ID (no provisioning):
+
+```python
+ep = Endpoint(id="abc123")
+job = await ep.runsync({"input": "hello"})
+print(job.output)
+```
+
+## How Mode Is Determined
+
+| Parameters | Mode |
+|-----------|------|
+| `name=` only | Decorator (your code) |
+| `image=` set | Client (deploys image, then HTTP calls) |
+| `id=` set | Client (connects to existing, no provisioning) |
+
+## Endpoint Constructor
+
+```python
+Endpoint(
+    name="endpoint-name",                  # required (unless id= set)
+    id=None,                               # connect to existing endpoint
+    gpu=GpuGroup.AMPERE_80,               # single GPU type (default: ANY)
+    gpu=[GpuGroup.ADA_24, GpuGroup.AMPERE_80],  # or list for auto-select by supply
+    cpu=CpuInstanceType.CPU5C_4_8,        # CPU type (mutually exclusive with gpu)
+    workers=5,                             # shorthand for (0, 5)
+    workers=(1, 5),                        # explicit (min, max)
+    idle_timeout=60,                       # seconds before scale-down (default: 60)
+    dependencies=["torch"],                # pip packages for remote exec
+    system_dependencies=["ffmpeg"],        # apt-get packages
+    image="org/image:tag",                 # pre-built Docker image (client mode)
+    env={"KEY": "val"},                    # environment variables
+    volume=NetworkVolume(...),             # persistent storage
+    gpu_count=1,                           # GPUs per worker
+    template=PodTemplate(containerDiskInGb=100),
+    flashboot=True,                        # fast cold starts
+    execution_timeout_ms=0,                # max execution time (0 = unlimited)
+)
+```
+
+- `gpu=` and `cpu=` are mutually exclusive
+- `workers=5` means `(0, 5)`. Default is `(0, 1)`
+- `idle_timeout` default is **60 seconds**
+- `flashboot=True` (default) -- enables fast cold starts via snapshot restore
+- `gpu_count` -- GPUs per worker (default 1), use >1 for multi-GPU models
+
+### NetworkVolume
+
+```python
+NetworkVolume(name="my-vol", size=100)  # size in GB, default 100
+```
+
+### PodTemplate
+
+```python
+PodTemplate(
+    containerDiskInGb=64,    # container disk size (default 64)
+    dockerArgs="",           # extra docker arguments
+    ports="",                # exposed ports
+    startScript="",          # script to run on start
+)
+```
+
+## EndpointJob
+
+Returned by `ep.run()` and `ep.runsync()` in client mode.
+
+```python
+job = await ep.run({"data": [1, 2, 3]})
+await job.wait(timeout=120)        # poll until done
+print(job.id, job.output, job.error, job.done)
+await job.cancel()
+```
+
+## GPU Types (GpuGroup)
+
+| Enum | GPU | VRAM |
+|------|-----|------|
+| `ANY` | any | varies |
+| `AMPERE_16` | RTX A4000 | 16GB |
+| `AMPERE_24` | RTX A5000/L4 | 24GB |
+| `AMPERE_48` | A40/A6000 | 48GB |
+| `AMPERE_80` | A100 | 80GB |
+| `ADA_24` | RTX 4090 | 24GB |
+| `ADA_32_PRO` | RTX 5090 | 32GB |
+| `ADA_48_PRO` | RTX 6000 Ada | 48GB |
+| `ADA_80_PRO` | H100 PCIe (80GB) / H100 HBM3 (80GB) / H100 NVL (94GB) | 80GB+ |
+| `HOPPER_141` | H200 | 141GB |
+
+## CPU Types (CpuInstanceType)
+
+| Enum | vCPU | RAM | Max Disk | Type |
+|------|------|-----|----------|------|
+| `CPU3G_1_4` | 1 | 4GB | 10GB | General |
+| `CPU3G_2_8` | 2 | 8GB | 20GB | General |
+| `CPU3G_4_16` | 4 | 16GB | 40GB | General |
+| `CPU3G_8_32` | 8 | 32GB | 80GB | General |
+| `CPU3C_1_2` | 1 | 2GB | 10GB | Compute |
+| `CPU3C_2_4` | 2 | 4GB | 20GB | Compute |
+| `CPU3C_4_8` | 4 | 8GB | 40GB | Compute |
+| `CPU3C_8_16` | 8 | 16GB | 80GB | Compute |
+| `CPU5C_1_2` | 1 | 2GB | 15GB | Compute (5th gen) |
+| `CPU5C_2_4` | 2 | 4GB | 30GB | Compute (5th gen) |
+| `CPU5C_4_8` | 4 | 8GB | 60GB | Compute (5th gen) |
+| `CPU5C_8_16` | 8 | 16GB | 120GB | Compute (5th gen) |
+
+```python
+from runpod_flash import Endpoint, CpuInstanceType
+
+@Endpoint(name="cpu-work", cpu=CpuInstanceType.CPU5C_4_8, workers=5, dependencies=["pandas"])
+async def process(data):
+    import pandas as pd
+    return pd.DataFrame(data).describe().to_dict()
+```
+
+## Common Patterns
+
+### CPU + GPU Pipeline
+
+```python
+from runpod_flash import Endpoint, GpuGroup, CpuInstanceType
+
+@Endpoint(name="preprocess", cpu=CpuInstanceType.CPU5C_4_8, workers=5, dependencies=["pandas"])
+async def preprocess(raw):
+    import pandas as pd
+    return pd.DataFrame(raw).to_dict("records")
+
+@Endpoint(name="infer", gpu=GpuGroup.AMPERE_80, workers=5, dependencies=["torch"])
+async def infer(clean):
+    import torch
+    t = torch.tensor([[v for v in r.values()] for r in clean], device="cuda")
+    return {"predictions": t.mean(dim=1).tolist()}
+
+async def pipeline(data):
+    return await infer(await preprocess(data))
+```
+
+### Parallel Execution
+
+```python
+import asyncio
+results = await asyncio.gather(compute(a), compute(b), compute(c))
+```
+
+## Gotchas
+
+1. **Imports outside function** -- most common error. Everything inside the decorated function.
+2. **Forgetting await** -- all decorated functions and client methods need `await`.
+3. **Missing dependencies** -- must list in `dependencies=[]`.
+4. **gpu/cpu are exclusive** -- pick one per Endpoint.
+5. **idle_timeout is seconds** -- default 60s, not minutes.
+6. **10MB payload limit** -- pass URLs, not large objects.
+7. **Client vs decorator** -- `image=`/`id=` = client. Otherwise = decorator.
+8. **Auto GPU switching requires workers >= 5** -- pass a list of GPU types (e.g. `gpu=[GpuGroup.ADA_24, GpuGroup.AMPERE_80]`) and set `workers=5` or higher. The platform only auto-switches GPU types based on supply when max workers is at least 5.
+9. **`runsync` timeout is 60s** -- cold starts can exceed 60s. Use `ep.runsync(data, timeout=120)` for first requests or use `ep.run()` + `job.wait()` instead.

--- a/mcp/computer-use/.agents/skills/runpodctl/SKILL.md
+++ b/mcp/computer-use/.agents/skills/runpodctl/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: runpodctl
+description: Runpod CLI to manage your GPU workloads.
+allowed-tools: Bash(runpodctl:*)
+compatibility: Linux, macOS
+metadata:
+  author: runpod
+  version: "2.2"
+license: Apache-2.0
+---
+
+# Runpodctl
+
+Manage GPU pods, serverless endpoints, templates, volumes, and models.
+
+> **Spelling:** "Runpod" (capital R). Command is `runpodctl` (lowercase).
+
+## Install
+
+```bash
+# Any platform (official installer)
+curl -sSL https://cli.runpod.net | bash
+
+# macOS (Homebrew)
+brew install runpod/runpodctl/runpodctl
+
+# macOS (manual — universal binary)
+mkdir -p ~/.local/bin && curl -sL https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-darwin-all.tar.gz | tar xz -C ~/.local/bin
+
+# Linux
+mkdir -p ~/.local/bin && curl -sL https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-linux-amd64.tar.gz | tar xz -C ~/.local/bin
+
+# Windows (PowerShell)
+Invoke-WebRequest -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.zip -OutFile runpodctl.zip; Expand-Archive runpodctl.zip -DestinationPath $env:LOCALAPPDATA\runpodctl; [Environment]::SetEnvironmentVariable('Path', $env:Path + ";$env:LOCALAPPDATA\runpodctl", 'User')
+```
+
+Ensure `~/.local/bin` is on your `PATH` (add `export PATH="$HOME/.local/bin:$PATH"` to `~/.bashrc` or `~/.zshrc`).
+
+## Quick start
+
+```bash
+runpodctl doctor                    # First time setup (API key + SSH)
+runpodctl gpu list                  # See available GPUs
+runpodctl hub search vllm           # Find a hub repo
+runpodctl serverless create --hub-id <id> --name "my-vllm"  # Deploy from hub
+runpodctl template search pytorch   # Find a template
+runpodctl pod create --template-id runpod-torch-v21 --gpu-id "NVIDIA GeForce RTX 4090"  # Create from template
+runpodctl pod list                  # List your pods
+```
+
+API key: https://runpod.io/console/user/settings
+
+## Commands
+
+### Pods
+
+```bash
+runpodctl pod list                                    # List running pods (default, like docker ps)
+runpodctl pod list --all                              # List all pods including exited
+runpodctl pod list --status exited                    # Filter by status (RUNNING, EXITED, etc.)
+runpodctl pod list --since 24h                        # Pods created within last 24 hours
+runpodctl pod list --created-after 2025-01-15         # Pods created after date
+runpodctl pod get <pod-id>                            # Get pod details (includes SSH info)
+runpodctl pod create --template-id runpod-torch-v21 --gpu-id "NVIDIA GeForce RTX 4090"  # Create from template
+runpodctl pod create --image "runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404" --gpu-id "NVIDIA GeForce RTX 4090"  # Create with image
+runpodctl pod create --compute-type cpu --image ubuntu:22.04  # Create CPU pod
+runpodctl pod start <pod-id>                          # Start stopped pod
+runpodctl pod stop <pod-id>                           # Stop running pod
+runpodctl pod restart <pod-id>                        # Restart pod
+runpodctl pod reset <pod-id>                          # Reset pod
+runpodctl pod update <pod-id> --name "new"            # Update pod
+runpodctl pod delete <pod-id>                         # Delete pod (aliases: rm, remove)
+```
+
+**List flags:** `--all` / `-a`, `--status`, `--since`, `--created-after`, `--name`, `--compute-type`
+**Get flags:** `--include-machine`, `--include-network-volume`
+
+**Create flags:** `--template-id` (required if no `--image`), `--image` (required if no `--template-id`), `--name`, `--gpu-id`, `--gpu-count`, `--compute-type`, `--ssh` (default true), `--container-disk-in-gb`, `--volume-in-gb`, `--volume-mount-path`, `--network-volume-id`, `--ports`, `--env`, `--cloud-type`, `--data-center-ids`, `--global-networking`, `--public-ip`
+
+### Hub
+
+Browse and search the Runpod Hub — a curated marketplace of deployable repos.
+
+```bash
+runpodctl hub list                                    # Top 10 by stars
+runpodctl hub list --type SERVERLESS                  # Only serverless repos
+runpodctl hub list --type POD                         # Only pod repos
+runpodctl hub list --category ai --limit 20           # Filter by category
+runpodctl hub list --order-by deploys                 # Order by deploys
+runpodctl hub list --owner runpod-workers             # Filter by repo owner
+runpodctl hub search vllm                             # Search for "vllm"
+runpodctl hub search whisper --type SERVERLESS        # Search serverless repos
+runpodctl hub get <listing-id>                        # Get by listing id
+runpodctl hub get runpod-workers/worker-vllm          # Get by owner/name
+```
+
+**List/search flags:** `--type` (POD, SERVERLESS), `--category`, `--order-by` (stars, deploys, createdAt, updatedAt, releasedAt, views), `--order-dir` (asc, desc), `--limit`, `--offset`, `--owner`
+
+### Serverless (alias: sls)
+
+```bash
+runpodctl serverless list                             # List all endpoints
+runpodctl serverless get <endpoint-id>                # Get endpoint details
+runpodctl serverless create --name "x" --template-id "tpl_abc"  # Create from template
+runpodctl serverless create --name "x" --hub-id <listing-id>    # Create from hub repo
+runpodctl serverless create --hub-id <id> --env MODEL_NAME=my-model  # Override hub env defaults
+runpodctl serverless update <endpoint-id> --workers-max 5       # Update endpoint
+runpodctl serverless delete <endpoint-id>             # Delete endpoint
+```
+
+**Create from hub:** `--hub-id` resolves the hub listing, extracts the build image and config (GPU IDs, container disk, env vars), creates an inline template, and deploys. Accepts both SERVERLESS and POD listing types. GPU IDs and env var defaults from the hub config are included automatically; override with `--gpu-id` and `--env`.
+
+**List flags:** `--include-template`, `--include-workers`
+**Update flags:** `--name`, `--workers-min`, `--workers-max`, `--idle-timeout`, `--scaler-type` (QUEUE_DELAY or REQUEST_COUNT), `--scaler-value`
+**Create flags:** `--name`, `--template-id` or `--hub-id` (one required), `--gpu-id`, `--gpu-count`, `--compute-type`, `--workers-min`, `--workers-max`, `--network-volume-id`, `--data-center-ids`, `--env`
+
+### Templates (alias: tpl)
+
+```bash
+runpodctl template list                               # Official + community (first 10)
+runpodctl template list --type official               # All official templates
+runpodctl template list --type community              # Community templates (first 10)
+runpodctl template list --type user                   # Your own templates
+runpodctl template list --all                         # Everything including user
+runpodctl template list --limit 50                    # Show 50 templates
+runpodctl template search pytorch                     # Search for "pytorch" templates
+runpodctl template search comfyui --limit 5           # Search, limit to 5 results
+runpodctl template search vllm --type official        # Search only official
+runpodctl template get <template-id>                  # Get template details (includes README, env, ports)
+runpodctl template create --name "x" --image "img"    # Create template
+runpodctl template create --name "x" --image "img" --serverless  # Create serverless template
+runpodctl template update <template-id> --name "new"  # Update template
+runpodctl template delete <template-id>               # Delete template
+```
+
+**List flags:** `--type` (official, community, user), `--limit`, `--offset`, `--all`
+**Create flags:** `--name`, `--image`, `--container-disk-in-gb`, `--volume-in-gb`, `--volume-mount-path`, `--ports`, `--env`, `--docker-start-cmd`, `--docker-entrypoint`, `--serverless`, `--readme`
+
+### Network Volumes (alias: nv)
+
+```bash
+runpodctl network-volume list                         # List all volumes
+runpodctl network-volume get <volume-id>              # Get volume details
+runpodctl network-volume create --name "x" --size 100 --data-center-id "US-GA-1"  # Create volume
+runpodctl network-volume update <volume-id> --name "new"  # Update volume
+runpodctl network-volume delete <volume-id>           # Delete volume
+```
+
+**Create flags:** `--name`, `--size`, `--data-center-id`
+
+### Models
+
+```bash
+runpodctl model list                                  # List your models
+runpodctl model list --all                            # List all models
+runpodctl model list --name "llama"                   # Filter by name
+runpodctl model list --provider "meta"                # Filter by provider
+runpodctl model add --name "my-model" --model-path ./model  # Add model
+runpodctl model remove --name "my-model"              # Remove model
+```
+
+### Registry (alias: reg)
+
+```bash
+runpodctl registry list                               # List registry auths
+runpodctl registry get <registry-id>                  # Get registry auth
+runpodctl registry create --name "x" --username "u" --password "p"  # Create registry auth
+runpodctl registry delete <registry-id>               # Delete registry auth
+```
+
+### Info
+
+```bash
+runpodctl user                                        # Account info and balance (alias: me)
+runpodctl gpu list                                    # List available GPUs
+runpodctl gpu list --include-unavailable              # Include unavailable GPUs
+runpodctl datacenter list                             # List datacenters (alias: dc)
+runpodctl billing pods                                # Pod billing history
+runpodctl billing serverless                          # Serverless billing history
+runpodctl billing network-volume                      # Volume billing history
+```
+
+### SSH
+
+```bash
+runpodctl ssh info <pod-id>                           # Get SSH info (command + key, does not connect)
+runpodctl ssh list-keys                               # List SSH keys
+runpodctl ssh add-key                                 # Add SSH key
+```
+
+**Agent note:** `ssh info` returns connection details, not an interactive session. If interactive SSH is not available, execute commands remotely via `ssh user@host "command"`.
+
+### File Transfer
+
+```bash
+runpodctl send <path>                                 # Send files (outputs code)
+runpodctl receive <code>                              # Receive files using code
+```
+
+### Utilities
+
+```bash
+runpodctl doctor                                      # Diagnose and fix CLI issues
+runpodctl update                                      # Update CLI
+runpodctl version                                     # Show version
+runpodctl completion                                  # Auto-detect shell and install completion
+```
+
+## URLs
+
+### Pod URLs
+
+Access exposed ports on your pod:
+
+```
+https://<pod-id>-<port>.proxy.runpod.net
+```
+
+Example: `https://abc123xyz-8888.proxy.runpod.net`
+
+### Serverless URLs
+
+```
+https://api.runpod.ai/v2/<endpoint-id>/run        # Async request
+https://api.runpod.ai/v2/<endpoint-id>/runsync    # Sync request
+https://api.runpod.ai/v2/<endpoint-id>/health     # Health check
+https://api.runpod.ai/v2/<endpoint-id>/status/<job-id>  # Job status
+```

--- a/mcp/computer-use/skills-lock.json
+++ b/mcp/computer-use/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "companion-clis": {
+      "source": "runpod/skills",
+      "sourceType": "github",
+      "skillPath": "companion-clis/SKILL.md",
+      "computedHash": "5ed7e388eaa94501995edee5e8fb5b9028d0a2f8029b1f4ea531f7adf98ac6ce"
+    },
+    "flash": {
+      "source": "runpod/skills",
+      "sourceType": "github",
+      "skillPath": "flash/SKILL.md",
+      "computedHash": "135a8c0a488aee2d1ca2170f5b8bf194febbf10bbb11c1ced3d123df0436847b"
+    },
+    "runpodctl": {
+      "source": "runpod/skills",
+      "sourceType": "github",
+      "skillPath": "runpodctl/SKILL.md",
+      "computedHash": "fd7a47f981eefecfc7d96f80856074aae382e49cbe611a6fad4eee8ef3bed5c4"
+    }
+  }
+}

--- a/mcp/computer-use/skills-lock.json
+++ b/mcp/computer-use/skills-lock.json
@@ -5,19 +5,19 @@
       "source": "runpod/skills",
       "sourceType": "github",
       "skillPath": "companion-clis/SKILL.md",
-      "computedHash": "5ed7e388eaa94501995edee5e8fb5b9028d0a2f8029b1f4ea531f7adf98ac6ce"
+      "computedHash": "854afe9ccc1f62685a3240896b7cc6efcdedd0a954d6cbbf9d516f593e73183e"
     },
     "flash": {
       "source": "runpod/skills",
       "sourceType": "github",
       "skillPath": "flash/SKILL.md",
-      "computedHash": "135a8c0a488aee2d1ca2170f5b8bf194febbf10bbb11c1ced3d123df0436847b"
+      "computedHash": "145041db131cd494852520f86237baf726205a4df439808c1c088cdcd9c0c4e8"
     },
     "runpodctl": {
       "source": "runpod/skills",
       "sourceType": "github",
       "skillPath": "runpodctl/SKILL.md",
-      "computedHash": "fd7a47f981eefecfc7d96f80856074aae382e49cbe611a6fad4eee8ef3bed5c4"
+      "computedHash": "7029208518ff084532fc060c0af72740cbe973f637ded4cc16f71fdeb55c6745"
     }
   }
 }


### PR DESCRIPTION
## What
Restores the 4 vendored skill artifacts the gal-computer-use fold dropped:
- `.agents/skills/companion-clis/SKILL.md`, `.agents/skills/flash/SKILL.md`, `.agents/skills/runpodctl/SKILL.md`, `skills-lock.json` (under `mcp/computer-use/`).

## Why
Verifier-confirmed missing from both monorepos: the env-VLM half of the source PR landed (`mcp/computer-use/src/uitars.ts`) but the vendored-skills half did not. Static markdown/JSON; byte-identical to source (archived `gal-computer-use-mcp-private` PR #2). No code/build impact.

## Note
The skill docs reference HuggingFace token *usage* (e.g. `export HF_TOKEN=hf_...`) as instructions — placeholders, no real secrets. `skills-lock.json` `computedHash` values are the upstream-normalized fingerprints (ported verbatim); if gal later runs a raw-sha256 lock verifier they may need regeneration against gal's checkout.

Addresses #453. Surfaced by the archived-repo disposition audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
