### PR TITLE
Group Dependabot security updates for npm + Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,15 @@
 ---
 # Dependabot - automated dependency updates
-# Issue #32 | Docs: https://docs.github.com/en/code-security/dependabot
+# Docs: https://docs.github.com/en/code-security/dependabot
+#
+# Security updates (the "Dependabot security updates" repo setting) raise fix PRs
+# for open alerts. The `groups: applies-to: security-updates` blocks below batch
+# those fix PRs (and minor/patch version PRs) so they don't arrive one-at-a-time.
+# NOTE: commit-message `prefix` includes "[ci]" so Dependabot's own commits satisfy
+# the `require-ci-intent` ruleset (which rejects commits lacking [ci]/[skip ci]).
 version: 2
 updates:
-  # GitHub Actions (the only package ecosystem in this docs repo)
+  # GitHub Actions
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -17,5 +23,59 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "deps(ci)"
+      prefix: "deps(ci) [ci]"
       include: scope
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  # npm — the app dirs that currently carry open security alerts
+  - package-ecosystem: npm
+    directories:
+      - "/"
+      - "/apps/website"
+      - "/packages/gal-code/packages/web"
+      - "/tools/demo-studio"
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps [ci]"
+      include: scope
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+        patterns: ["*"]
+
+  # Go modules — services workspace (open high-severity alerts)
+  - package-ecosystem: gomod
+    directory: /services
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps(go) [ci]"
+      include: scope
+    groups:
+      go-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      go-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+        patterns: ["*"]


### PR DESCRIPTION
Fixes #468

What

The repo had open Dependabot alerts but no security fix PRs were being raised. Dependabot security updates are now enabled; this adds a grouped `.github/dependabot.yml` so fix PRs (and minor/patch version PRs) are batched rather than arriving one per advisory.

Changes

- npm: group security + minor/patch updates for `/`, `/apps/website`, `/packages/gal-code/packages/web`, `/tools/demo-studio` (the app dirs with open alerts)
- gomod: group security + minor/patch updates for `/services`
- Preserve the existing `github-actions` entry
- commit-message `prefix` carries `[ci]` so Dependabot’s own commits satisfy the `require-ci-intent` ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)