### PR TITLE
sdks/evals: port prediction-file adapter + managed-agent runner + report-submitter [ci]

### DIFF
--- a/sdks/evals/docs/prediction-files.md
+++ b/sdks/evals/docs/prediction-files.md
@@ -1,0 +1,101 @@
+# Prediction Files
+
+Prediction files connect real candidate behavior to stable evaluation suites.
+
+They are intentionally simple:
+
+- one `suiteId`;
+- one `caseId` per prediction;
+- one `output` object matching the suite's expected output paths;
+- optional subject and metadata.
+
+Schema: `schemas/gal-evals-predictions.schema.json`
+
+## Why They Exist
+
+`gal-evals` should not deploy agents, own credentials, or call live product
+systems. Workers and runtime repos do that. A prediction file is the contract
+between those runtime systems and this evaluation repo.
+
+## Example
+
+```json
+{
+  "schemaVersion": "gal.evals.predictions.v1",
+  "suiteId": "gal.ops-triage.email.v1",
+  "predictions": [
+    {
+      "caseId": "email-platform-action",
+      "output": {
+        "label": "platform",
+        "createTask": true,
+        "archive": false
+      }
+    }
+  ]
+}
+```
+
+## CLI
+
+```bash
+gal-evals \
+  --suite suites/email-triage.json \
+  --adapter prediction-file \
+  --predictions predictions.json \
+  --output report.json
+```
+
+The CLI fails when:
+
+- `suiteId` does not match;
+- the prediction file contains unknown case IDs;
+- a suite case has no prediction;
+- report gates fail.
+
+## API Submission
+
+Workers can submit the generated report back to a queued managed-agent eval run:
+
+```bash
+GAL_EVAL_SUBMIT_TOKEN="$RUNNER_TOKEN" gal-evals \
+  --suite suites/email-triage.json \
+  --adapter prediction-file \
+  --predictions predictions.json \
+  --submit-api-url https://api.gal.run \
+  --submit-org example-org \
+  --submit-agent gal.ops-triage \
+  --submit-version 2026-05-16.1 \
+  --submit-run-id eval-123
+```
+
+Use `--submit-token-env <ENV_NAME>` when the runner token lives in a different
+environment variable. The token is only used as an HTTP bearer token; `gal-evals`
+still does not fetch live mailbox data or own connector credentials.
+
+Runtime workers can also import `claimEvaluationRun` from `@gal-run/gal-evals`
+before executing the candidate. Claiming moves the API eval run to `running` and
+returns a `gal.managed_agents.eval_work_packet.v1` work packet with agent
+metadata, version runtime refs, execution target refs, runner refs, connector
+refs, vault ref IDs, suite ID, and the report submission endpoint.
+
+## Managed-Agent Worker Runner
+
+When a worker uses the `@gal-run/gal-agents` managed-agent worker wrapper, it can
+wrap a prediction file as a structural runner. The worker resolves deployment
+resources and handles claim/report submission; the runner only scores
+already-produced predictions:
+
+```ts
+import { createPredictionFileManagedAgentRunner } from '@gal-run/gal-evals'
+
+const runner = createPredictionFileManagedAgentRunner({
+  suite,
+  predictionFile,
+  taskTypes: ['ops.email.triage'],
+})
+```
+
+The runner validates that the work packet suite, eval suite, and prediction file
+suite all match before scoring. It does not open Gmail, load OAuth credentials,
+or mutate mailbox state.

--- a/sdks/evals/fixtures/email-triage-perfect-predictions.json
+++ b/sdks/evals/fixtures/email-triage-perfect-predictions.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "gal.evals.predictions.v1",
+  "suiteId": "gal.ops-triage.email.v1",
+  "subject": {
+    "kind": "managed_agent",
+    "agentId": "gal.ops-triage",
+    "taskType": "ops.email.triage",
+    "version": "fixture-perfect"
+  },
+  "generatedAt": "2026-05-16T00:00:00.000Z",
+  "predictions": [
+    {
+      "caseId": "email-newsletter-news",
+      "output": { "label": "example-news", "createTask": false, "archive": true }
+    },
+    {
+      "caseId": "email-cloud-billing",
+      "output": { "label": "cloud", "createTask": true, "archive": false }
+    },
+    {
+      "caseId": "email-review-digest",
+      "output": { "label": "review", "createTask": false, "archive": true }
+    },
+    {
+      "caseId": "email-vcs-ci-success",
+      "output": { "label": "vcs", "createTask": false, "archive": true }
+    },
+    {
+      "caseId": "email-directory-report",
+      "output": { "label": "directory", "createTask": false, "archive": true }
+    },
+    {
+      "caseId": "email-bank-transaction",
+      "output": { "label": "bank-example", "createTask": false, "archive": false }
+    },
+    {
+      "caseId": "email-platform-action",
+      "output": { "label": "platform", "createTask": true, "archive": false }
+    }
+  ],
+  "metadata": {
+    "source": "synthetic fixture"
+  }
+}

--- a/sdks/evals/package.json
+++ b/sdks/evals/package.json
@@ -12,6 +12,8 @@
   "files": [
     "dist",
     "docs",
+    "fixtures",
+    "schemas",
     "suites",
     "README.md"
   ],
@@ -20,7 +22,8 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "eval:email": "npm run build && node dist/cli/evaluate.js --suite suites/email-triage.json --adapter email-rules",
-    "eval:all": "npm run eval:email"
+    "eval:email:predictions": "npm run build && node dist/cli/evaluate.js --suite suites/email-triage.json --adapter prediction-file --predictions fixtures/email-triage-perfect-predictions.json",
+    "eval:all": "npm run eval:email && npm run eval:email:predictions"
   },
   "devDependencies": {
     "@types/node": "^25.8.0",

--- a/sdks/evals/schemas/gal-evals-predictions.schema.json
+++ b/sdks/evals/schemas/gal-evals-predictions.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gal.run/gal-evals-predictions.schema.json",
+  "title": "GAL Evaluation Predictions",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "suiteId", "predictions"],
+  "properties": {
+    "schemaVersion": { "const": "gal.evals.predictions.v1" },
+    "suiteId": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "generatedAt": {
+      "type": "string"
+    },
+    "predictions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["caseId", "output"],
+        "properties": {
+          "caseId": { "type": "string", "minLength": 1 },
+          "output": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/sdks/evals/schemas/gal-evals-report.schema.json
+++ b/sdks/evals/schemas/gal-evals-report.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gal.run/gal-evals-report.schema.json",
+  "title": "GAL Evaluation Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "suiteId",
+    "suiteName",
+    "evaluatorId",
+    "adapterId",
+    "subject",
+    "generatedAt",
+    "score",
+    "passed",
+    "metrics",
+    "cases",
+    "suggestions"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "gal.evals.report.v1" },
+    "suiteId": { "type": "string", "minLength": 1 },
+    "suiteName": { "type": "string", "minLength": 1 },
+    "evaluatorId": { "type": "string", "minLength": 1 },
+    "adapterId": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "generatedAt": { "type": "string" },
+    "score": { "type": "number", "minimum": 0, "maximum": 1 },
+    "passed": { "type": "boolean" },
+    "metrics": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/metric" }
+    },
+    "cases": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/caseResult" }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "$defs": {
+    "metric": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["metric", "score", "correct", "total", "passed"],
+      "properties": {
+        "metric": { "type": "string" },
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "correct": { "type": "number" },
+        "total": { "type": "number" },
+        "passed": { "type": "boolean" },
+        "gate": { "type": "object" }
+      }
+    },
+    "caseResult": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["caseId", "score", "passed", "output", "fields"],
+      "properties": {
+        "caseId": { "type": "string" },
+        "title": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "passed": { "type": "boolean" },
+        "output": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/fieldResult" }
+        }
+      }
+    },
+    "fieldResult": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["path", "metric", "score", "weight", "passed"],
+      "properties": {
+        "path": { "type": "string" },
+        "metric": { "type": "string" },
+        "expected": true,
+        "actual": true,
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "weight": { "type": "number" },
+        "passed": { "type": "boolean" },
+        "suggestion": { "type": "string" }
+      }
+    }
+  }
+}

--- a/sdks/evals/schemas/gal-evals-suite.schema.json
+++ b/sdks/evals/schemas/gal-evals-suite.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.gal.run/gal-evals-suite.schema.json",
+  "title": "GAL Evaluation Suite",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "name",
+    "subject",
+    "evaluatorId",
+    "gates",
+    "fields",
+    "cases"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "gal.evals.suite.v1" },
+    "id": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "subject": { "$ref": "#/$defs/subject" },
+    "evaluatorId": { "type": "string", "minLength": 1 },
+    "gates": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/gate" }
+    },
+    "fields": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/field" }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/case" }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": [
+            "managed_agent",
+            "agent_card",
+            "runtime_adapter",
+            "tool_connector",
+            "policy"
+          ]
+        },
+        "agentId": { "type": "string" },
+        "taskType": { "type": "string" },
+        "version": { "type": "string" },
+        "repo": { "type": "string" }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric", "minScore"],
+      "properties": {
+        "metric": { "type": "string", "minLength": 1 },
+        "minScore": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "field": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "kind": {
+          "enum": ["exact_match", "boolean_match", "number_range", "custom"]
+        },
+        "weight": { "type": "number", "exclusiveMinimum": 0 },
+        "min": { "type": "number" },
+        "max": { "type": "number" }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "input", "expected"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "input": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "expected": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/field" }
+        }
+      }
+    }
+  }
+}

--- a/sdks/evals/src/cli/evaluate.ts
+++ b/sdks/evals/src/cli/evaluate.ts
@@ -2,8 +2,13 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { emailRulesAdapter } from '../email/email-rules-adapter.js'
+import {
+  PredictionFileAdapter,
+  assertPredictionFileMatchesSuite,
+} from '../core/prediction-file-adapter.js'
 import { formatEvaluationReport, runEvaluationSuite } from '../core/runner.js'
-import type { GalEvalAdapter, GalEvalSuite } from '../core/types.js'
+import { submitEvaluationReport } from '../core/report-submitter.js'
+import type { GalEvalAdapter, GalEvalPredictionFile, GalEvalSuite } from '../core/types.js'
 
 const adapters: Record<string, GalEvalAdapter> = {
   [emailRulesAdapter.id]: emailRulesAdapter,
@@ -13,13 +18,15 @@ const args = parseArgs(process.argv.slice(2))
 const suitePath = args['suite']
 const adapterId = args['adapter'] ?? 'email-rules'
 const outputPath = args['output']
+const predictionsPath = args['predictions']
+const submitApiUrl = args['submit-api-url']
 
 if (!suitePath) {
   throw new Error('Missing --suite <path>')
 }
 
 const suite = JSON.parse(await readFile(resolve(suitePath), 'utf8')) as GalEvalSuite
-const adapter = adapters[adapterId]
+const adapter = await resolveAdapter(adapterId, suite, predictionsPath)
 
 if (!adapter) {
   throw new Error(`Unknown adapter ${adapterId}. Available adapters: ${Object.keys(adapters).join(', ')}`)
@@ -30,6 +37,18 @@ console.log(formatEvaluationReport(report))
 
 if (outputPath) {
   await writeFile(resolve(outputPath), `${JSON.stringify(report, null, 2)}\n`)
+}
+
+if (submitApiUrl) {
+  const evalRun = await submitEvaluationReport(report, {
+    apiBaseUrl: submitApiUrl,
+    orgName: requireArg(args, 'submit-org'),
+    agentId: requireArg(args, 'submit-agent'),
+    version: requireArg(args, 'submit-version'),
+    runId: requireArg(args, 'submit-run-id'),
+    bearerToken: resolveSubmitToken(args),
+  })
+  console.log(`Submitted report to eval run ${evalRun.runId}: ${evalRun.status} / ${evalRun.gateStatus}`)
 }
 
 process.exitCode = report.passed ? 0 : 1
@@ -55,4 +74,47 @@ function parseArgs(argv: string[]): Record<string, string | undefined> {
   }
 
   return parsed
+}
+
+function requireArg(args: Record<string, string | undefined>, key: string): string {
+  const value = args[key]?.trim()
+  if (!value) {
+    throw new Error(`Missing --${key} <value>`)
+  }
+  return value
+}
+
+function resolveSubmitToken(args: Record<string, string | undefined>): string | undefined {
+  const envName = args['submit-token-env']?.trim()
+  if (envName) {
+    return process.env[envName]
+  }
+  return process.env['GAL_EVAL_SUBMIT_TOKEN']
+}
+
+async function resolveAdapter(
+  adapterId: string,
+  suite: GalEvalSuite,
+  predictionsPath: string | undefined,
+): Promise<GalEvalAdapter> {
+  if (adapterId === 'prediction-file') {
+    if (!predictionsPath) {
+      throw new Error('Missing --predictions <path> for prediction-file adapter')
+    }
+
+    const predictionFile = JSON.parse(
+      await readFile(resolve(predictionsPath), 'utf8'),
+    ) as GalEvalPredictionFile
+
+    assertPredictionFileMatchesSuite(predictionFile, suite)
+    return new PredictionFileAdapter(predictionFile)
+  }
+
+  const adapter = adapters[adapterId]
+
+  if (!adapter) {
+    throw new Error(`Unknown adapter ${adapterId}. Available adapters: ${Object.keys(adapters).concat('prediction-file').join(', ')}`)
+  }
+
+  return adapter
 }

--- a/sdks/evals/src/core/managed-agent-runner.test.ts
+++ b/sdks/evals/src/core/managed-agent-runner.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createGalEvalsManagedAgentRunner,
+  createPredictionFileManagedAgentRunner,
+} from './managed-agent-runner.js'
+import {
+  GAL_EVAL_PREDICTIONS_SCHEMA_VERSION,
+  GAL_EVAL_SUITE_SCHEMA_VERSION,
+  type GalEvalPredictionFile,
+  type GalEvalSuite,
+} from './types.js'
+
+describe('managed-agent eval runner bridge', () => {
+  it('exposes gal-evals suites as structural managed-agent runners', async () => {
+    const suite = makeSuite()
+    const runner = createGalEvalsManagedAgentRunner({
+      suite,
+      adapter: {
+        id: 'echo-label',
+        async evaluateCase(testCase) {
+          return { label: testCase.expected['label'] }
+        },
+      },
+      taskTypes: ['ops.email.triage'],
+    })
+
+    const workPacket = {
+      agent: { taskType: 'ops.email.triage', agentCardRef: 'gal-agents://agent-cards/ops-triage/email' },
+      evalRun: { suiteId: suite.id },
+    }
+    const report = await runner.run(workPacket)
+
+    expect(runner.id).toBe('gal-evals:echo-label:gal.ops-triage.email.v1')
+    expect(runner.canRun(workPacket)).toBe(true)
+    expect(report.passed).toBe(true)
+    expect(report.adapterId).toBe('echo-label')
+  })
+
+  it('creates prediction-file runners for worker-produced outputs', async () => {
+    const suite = makeSuite()
+    const predictionFile: GalEvalPredictionFile = {
+      schemaVersion: GAL_EVAL_PREDICTIONS_SCHEMA_VERSION,
+      suiteId: suite.id,
+      predictions: [
+        {
+          caseId: 'case-1',
+          output: { label: 'github' },
+        },
+      ],
+    }
+
+    const runner = createPredictionFileManagedAgentRunner({
+      suite,
+      predictionFile,
+      taskTypes: ['ops.email.triage'],
+    })
+    const report = await runner.run({
+      agent: { taskType: 'ops.email.triage' },
+      evalRun: { suiteId: suite.id },
+    })
+
+    expect(report.schemaVersion).toBe('gal.evals.report.v1')
+    expect(report.passed).toBe(true)
+    expect(report.adapterId).toBe('prediction-file')
+  })
+
+  it('rejects mismatched work packets before scoring', async () => {
+    const runner = createGalEvalsManagedAgentRunner({
+      suite: makeSuite(),
+      adapter: {
+        id: 'never-called',
+        async evaluateCase() {
+          return { label: 'github' }
+        },
+      },
+    })
+
+    await expect(
+      runner.run({
+        agent: {},
+        evalRun: { suiteId: 'wrong-suite' },
+      }),
+    ).rejects.toThrow('does not match suite')
+  })
+})
+
+function makeSuite(): GalEvalSuite {
+  return {
+    schemaVersion: GAL_EVAL_SUITE_SCHEMA_VERSION,
+    id: 'gal.ops-triage.email.v1',
+    name: 'Email triage',
+    subject: {
+      kind: 'managed_agent',
+      agentId: 'gal.ops-triage.email',
+      taskType: 'ops.email.triage',
+    },
+    evaluatorId: 'gal-evals',
+    gates: [{ metric: 'overall', minScore: 1 }],
+    fields: [{ path: 'label', kind: 'exact_match' }],
+    cases: [
+      {
+        id: 'case-1',
+        input: { subject: '[repo] PR merged' },
+        expected: { label: 'github' },
+      },
+    ],
+  }
+}

--- a/sdks/evals/src/core/managed-agent-runner.ts
+++ b/sdks/evals/src/core/managed-agent-runner.ts
@@ -1,0 +1,93 @@
+import { PredictionFileAdapter, assertPredictionFileMatchesSuite } from './prediction-file-adapter.js'
+import { runEvaluationSuite } from './runner.js'
+import type {
+  GalEvalAdapter,
+  GalEvalPredictionFile,
+  GalEvalReport,
+  GalEvalSuite,
+} from './types.js'
+
+export interface ManagedAgentEvalWorkPacketLike {
+  agent: {
+    taskType?: string
+    agentCardRef?: string
+  }
+  evalRun: {
+    suiteId: string
+  }
+}
+
+export interface ManagedAgentEvalRunnerLike {
+  id: string
+  suiteIds: readonly string[]
+  taskTypes?: readonly string[]
+  agentCardRefs?: readonly string[]
+  canRun(workPacket: ManagedAgentEvalWorkPacketLike): boolean
+  run(workPacket: ManagedAgentEvalWorkPacketLike): Promise<GalEvalReport>
+}
+
+export interface CreateGalEvalsManagedAgentRunnerOptions {
+  id?: string
+  suite: GalEvalSuite
+  adapter: GalEvalAdapter
+  taskTypes?: readonly string[]
+  agentCardRefs?: readonly string[]
+}
+
+export interface CreatePredictionFileManagedAgentRunnerOptions
+  extends Omit<CreateGalEvalsManagedAgentRunnerOptions, 'adapter'> {
+  predictionFile: GalEvalPredictionFile
+}
+
+export function createGalEvalsManagedAgentRunner(
+  options: CreateGalEvalsManagedAgentRunnerOptions,
+): ManagedAgentEvalRunnerLike {
+  const suiteIds = [options.suite.id]
+  return {
+    id: options.id ?? `gal-evals:${options.adapter.id}:${options.suite.id}`,
+    suiteIds,
+    taskTypes: options.taskTypes,
+    agentCardRefs: options.agentCardRefs,
+    canRun(workPacket) {
+      if (workPacket.evalRun.suiteId !== options.suite.id) return false
+      if (options.taskTypes?.length && !options.taskTypes.includes(workPacket.agent.taskType ?? '')) {
+        return false
+      }
+      if (
+        options.agentCardRefs?.length &&
+        !options.agentCardRefs.includes(workPacket.agent.agentCardRef ?? '')
+      ) {
+        return false
+      }
+      return true
+    },
+    async run(workPacket) {
+      assertWorkPacketMatchesSuite(workPacket, options.suite)
+      return runEvaluationSuite(options.suite, options.adapter)
+    },
+  }
+}
+
+export function createPredictionFileManagedAgentRunner(
+  options: CreatePredictionFileManagedAgentRunnerOptions,
+): ManagedAgentEvalRunnerLike {
+  assertPredictionFileMatchesSuite(options.predictionFile, options.suite)
+  return createGalEvalsManagedAgentRunner({
+    id: options.id ?? `gal-evals:prediction-file:${options.suite.id}`,
+    suite: options.suite,
+    adapter: new PredictionFileAdapter(options.predictionFile),
+    taskTypes: options.taskTypes,
+    agentCardRefs: options.agentCardRefs,
+  })
+}
+
+export function assertWorkPacketMatchesSuite(
+  workPacket: ManagedAgentEvalWorkPacketLike,
+  suite: GalEvalSuite,
+): void {
+  if (workPacket.evalRun.suiteId !== suite.id) {
+    throw new Error(
+      `Managed-agent work packet suiteId ${workPacket.evalRun.suiteId} does not match suite ${suite.id}`,
+    )
+  }
+}

--- a/sdks/evals/src/core/prediction-file-adapter.test.ts
+++ b/sdks/evals/src/core/prediction-file-adapter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { runEvaluationSuite } from './runner.js'
+import { PredictionFileAdapter, assertPredictionFileMatchesSuite } from './prediction-file-adapter.js'
+import {
+  GAL_EVAL_PREDICTIONS_SCHEMA_VERSION,
+  GAL_EVAL_SUITE_SCHEMA_VERSION,
+  type GalEvalPredictionFile,
+  type GalEvalSuite,
+} from './types.js'
+
+describe('PredictionFileAdapter', () => {
+  const suite: GalEvalSuite = {
+    schemaVersion: GAL_EVAL_SUITE_SCHEMA_VERSION,
+    id: 'prediction-suite',
+    name: 'Prediction Suite',
+    subject: { kind: 'managed_agent', agentId: 'demo.agent' },
+    evaluatorId: 'demo',
+    gates: [{ metric: 'overall', minScore: 1 }],
+    fields: [{ path: 'label', kind: 'exact_match' }],
+    cases: [
+      {
+        id: 'case-1',
+        input: {},
+        expected: { label: 'expected' },
+      },
+    ],
+  }
+
+  it('scores outputs emitted by a prediction file', async () => {
+    const predictions: GalEvalPredictionFile = {
+      schemaVersion: GAL_EVAL_PREDICTIONS_SCHEMA_VERSION,
+      suiteId: suite.id,
+      predictions: [{ caseId: 'case-1', output: { label: 'expected' } }],
+    }
+
+    const report = await runEvaluationSuite(suite, new PredictionFileAdapter(predictions))
+
+    expect(report.passed).toBe(true)
+    expect(report.score).toBe(1)
+  })
+
+  it('rejects predictions for the wrong suite', () => {
+    const predictions: GalEvalPredictionFile = {
+      schemaVersion: GAL_EVAL_PREDICTIONS_SCHEMA_VERSION,
+      suiteId: 'other-suite',
+      predictions: [],
+    }
+
+    expect(() => assertPredictionFileMatchesSuite(predictions, suite)).toThrow(
+      'does not match suite',
+    )
+  })
+})

--- a/sdks/evals/src/core/prediction-file-adapter.ts
+++ b/sdks/evals/src/core/prediction-file-adapter.ts
@@ -1,0 +1,47 @@
+import type {
+  GalEvalAdapter,
+  GalEvalCase,
+  GalEvalPredictionFile,
+  GalEvalSuite,
+} from './types.js'
+
+export class PredictionFileAdapter implements GalEvalAdapter {
+  readonly id = 'prediction-file'
+  private readonly predictions: Map<string, Record<string, unknown>>
+
+  constructor(predictionFile: GalEvalPredictionFile) {
+    this.predictions = new Map(
+      predictionFile.predictions.map(prediction => [prediction.caseId, prediction.output]),
+    )
+  }
+
+  async evaluateCase(testCase: GalEvalCase, _suite: GalEvalSuite): Promise<Record<string, unknown>> {
+    const output = this.predictions.get(testCase.id)
+
+    if (!output) {
+      throw new Error(`Prediction file is missing output for case ${testCase.id}`)
+    }
+
+    return output
+  }
+}
+
+export function assertPredictionFileMatchesSuite(
+  predictionFile: GalEvalPredictionFile,
+  suite: GalEvalSuite,
+): void {
+  if (predictionFile.suiteId !== suite.id) {
+    throw new Error(
+      `Prediction file suiteId ${predictionFile.suiteId} does not match suite ${suite.id}`,
+    )
+  }
+
+  const suiteCaseIds = new Set(suite.cases.map(testCase => testCase.id))
+  const extraPredictions = predictionFile.predictions
+    .map(prediction => prediction.caseId)
+    .filter(caseId => !suiteCaseIds.has(caseId))
+
+  if (extraPredictions.length > 0) {
+    throw new Error(`Prediction file contains unknown case ids: ${extraPredictions.join(', ')}`)
+  }
+}

--- a/sdks/evals/src/core/report-submitter.test.ts
+++ b/sdks/evals/src/core/report-submitter.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest'
+import { claimEvaluationRun, submitEvaluationReport } from './report-submitter.js'
+import {
+  GAL_EVAL_REPORT_SCHEMA_VERSION,
+  type GalEvalReport,
+} from './types.js'
+
+const report: GalEvalReport = {
+  schemaVersion: GAL_EVAL_REPORT_SCHEMA_VERSION,
+  suiteId: 'gal.ops-triage.email.v1',
+  suiteName: 'Email triage',
+  evaluatorId: 'gal-evals',
+  adapterId: 'prediction-file',
+  subject: {
+    kind: 'managed_agent',
+    agentId: 'gal.ops-triage',
+    taskType: 'ops.email.triage',
+    version: '2026-05-16.1',
+  },
+  generatedAt: '2026-05-16T00:00:00.000Z',
+  score: 1,
+  passed: true,
+  metrics: [],
+  cases: [],
+  suggestions: [],
+}
+
+describe('submitEvaluationReport', () => {
+  it('claims a managed-agent eval run and returns the work packet', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        workPacket: {
+          schemaVersion: 'gal.managed_agents.eval_work_packet.v1',
+          agent: { id: 'gal.ops-triage', taskType: 'ops.email.triage' },
+          version: { runtimeRef: 'gal-worker://managed-agent-runtime' },
+          evalRun: {
+            runId: 'eval-1',
+            status: 'running',
+            gateStatus: 'not_run',
+          },
+          submission: {
+            method: 'POST',
+            path: '/api/managed-agents/example-org/gal.ops-triage/versions/2026-05-16.1/eval-runs/eval-1/report',
+            reportSchemaVersion: 'gal.evals.report.v1',
+          },
+        },
+      }),
+    })
+
+    const workPacket = await claimEvaluationRun(
+      {
+        apiBaseUrl: 'https://api.gal.run/',
+        orgName: 'Example Org',
+        agentId: 'gal.ops-triage',
+        version: '2026-05-16.1',
+        runId: 'eval-1',
+        bearerToken: 'runner-token',
+      },
+      fetchImpl as unknown as typeof fetch,
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.gal.run/api/managed-agents/Example%20Org/gal.ops-triage/versions/2026-05-16.1/eval-runs/eval-1/claim',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer runner-token',
+        },
+        body: JSON.stringify({}),
+      },
+    )
+    expect(workPacket.evalRun.status).toBe('running')
+    expect(workPacket.schemaVersion).toBe('gal.managed_agents.eval_work_packet.v1')
+    expect(workPacket.submission.reportSchemaVersion).toBe('gal.evals.report.v1')
+  })
+
+  it('posts a gal.evals.report.v1 snapshot to the managed-agent eval run', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        evalRun: {
+          runId: 'eval-1',
+          status: 'completed',
+          gateStatus: 'passed',
+        },
+      }),
+    })
+
+    const evalRun = await submitEvaluationReport(
+      report,
+      {
+        apiBaseUrl: 'https://api.gal.run/',
+        orgName: 'Example Org',
+        agentId: 'gal.ops-triage',
+        version: '2026-05-16.1',
+        runId: 'eval-1',
+        bearerToken: 'runner-token',
+      },
+      fetchImpl as unknown as typeof fetch,
+    )
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.gal.run/api/managed-agents/Example%20Org/gal.ops-triage/versions/2026-05-16.1/eval-runs/eval-1/report',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer runner-token',
+        },
+        body: JSON.stringify({ reportSnapshot: report }),
+      },
+    )
+    expect(evalRun.gateStatus).toBe('passed')
+  })
+
+  it('surfaces API submission failures', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({ error: 'invalid_managed_agent_request' }),
+    })
+
+    await expect(
+      submitEvaluationReport(
+        report,
+        {
+          apiBaseUrl: 'https://api.gal.run',
+          orgName: 'example-org',
+          agentId: 'gal.ops-triage',
+          version: '2026-05-16.1',
+          runId: 'eval-1',
+        },
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow('invalid_managed_agent_request')
+  })
+})

--- a/sdks/evals/src/core/report-submitter.ts
+++ b/sdks/evals/src/core/report-submitter.ts
@@ -1,0 +1,121 @@
+import type { GalEvalReport } from './types.js'
+
+export interface SubmitEvaluationReportOptions {
+  apiBaseUrl: string
+  orgName: string
+  agentId: string
+  version: string
+  runId: string
+  bearerToken?: string
+}
+
+export interface SubmittedEvalRun {
+  runId: string
+  status: string
+  gateStatus: string
+  [key: string]: unknown
+}
+
+export interface ManagedAgentEvalWorkPacket {
+  schemaVersion: 'gal.managed_agents.eval_work_packet.v1'
+  agent: Record<string, unknown>
+  version: Record<string, unknown>
+  evalRun: SubmittedEvalRun
+  submission: {
+    method: 'POST'
+    path: string
+    reportSchemaVersion: 'gal.evals.report.v1'
+  }
+}
+
+type FetchLike = typeof fetch
+
+function buildEvalRunBasePath(options: SubmitEvaluationReportOptions): string {
+  return [
+    'api',
+    'managed-agents',
+    encodeURIComponent(options.orgName),
+    encodeURIComponent(options.agentId),
+    'versions',
+    encodeURIComponent(options.version),
+    'eval-runs',
+    encodeURIComponent(options.runId),
+  ].join('/')
+}
+
+export function buildReportSubmissionUrl(options: SubmitEvaluationReportOptions): string {
+  const baseUrl = options.apiBaseUrl.replace(/\/+$/, '')
+  return [baseUrl, buildEvalRunBasePath(options), 'report'].join('/')
+}
+
+export function buildEvalRunClaimUrl(options: SubmitEvaluationReportOptions): string {
+  const baseUrl = options.apiBaseUrl.replace(/\/+$/, '')
+  return [baseUrl, buildEvalRunBasePath(options), 'claim'].join('/')
+}
+
+function buildHeaders(bearerToken: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (bearerToken) {
+    headers['Authorization'] = `Bearer ${bearerToken}`
+  }
+  return headers
+}
+
+export async function claimEvaluationRun(
+  options: SubmitEvaluationReportOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<ManagedAgentEvalWorkPacket> {
+  const response = await fetchImpl(buildEvalRunClaimUrl(options), {
+    method: 'POST',
+    headers: buildHeaders(options.bearerToken),
+    body: JSON.stringify({}),
+  })
+  const data = await response.json().catch(() => ({}))
+
+  if (!response.ok) {
+    const message =
+      typeof data?.error === 'string'
+        ? data.error
+        : typeof data?.message === 'string'
+          ? data.message
+          : 'Failed to claim evaluation run'
+    throw new Error(message)
+  }
+
+  if (!data?.workPacket || typeof data.workPacket !== 'object') {
+    throw new Error('Eval run claim response did not include workPacket')
+  }
+
+  return data.workPacket as ManagedAgentEvalWorkPacket
+}
+
+export async function submitEvaluationReport(
+  report: GalEvalReport,
+  options: SubmitEvaluationReportOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<SubmittedEvalRun> {
+  const response = await fetchImpl(buildReportSubmissionUrl(options), {
+    method: 'POST',
+    headers: buildHeaders(options.bearerToken),
+    body: JSON.stringify({ reportSnapshot: report }),
+  })
+  const data = await response.json().catch(() => ({}))
+
+  if (!response.ok) {
+    const message =
+      typeof data?.error === 'string'
+        ? data.error
+        : typeof data?.message === 'string'
+          ? data.message
+          : 'Failed to submit evaluation report'
+    throw new Error(message)
+  }
+
+  if (!data?.evalRun || typeof data.evalRun !== 'object') {
+    throw new Error('Report submission response did not include evalRun')
+  }
+
+  return data.evalRun as SubmittedEvalRun
+}

--- a/sdks/evals/src/core/types.ts
+++ b/sdks/evals/src/core/types.ts
@@ -1,5 +1,6 @@
 export const GAL_EVAL_SUITE_SCHEMA_VERSION = 'gal.evals.suite.v1' as const
 export const GAL_EVAL_REPORT_SCHEMA_VERSION = 'gal.evals.report.v1' as const
+export const GAL_EVAL_PREDICTIONS_SCHEMA_VERSION = 'gal.evals.predictions.v1' as const
 
 export type GalEvalSubjectKind =
   | 'managed_agent'
@@ -101,4 +102,19 @@ export interface GalEvalReport {
   metrics: GalEvalMetricResult[]
   cases: GalEvalCaseResult[]
   suggestions: string[]
+}
+
+export interface GalEvalPrediction {
+  caseId: string
+  output: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
+export interface GalEvalPredictionFile {
+  schemaVersion: typeof GAL_EVAL_PREDICTIONS_SCHEMA_VERSION
+  suiteId: string
+  subject?: GalEvalSubject
+  generatedAt?: string
+  predictions: GalEvalPrediction[]
+  metadata?: Record<string, unknown>
 }

--- a/sdks/evals/src/index.ts
+++ b/sdks/evals/src/index.ts
@@ -1,4 +1,7 @@
 export * from './core/types.js'
 export * from './core/runner.js'
+export * from './core/prediction-file-adapter.js'
+export * from './core/report-submitter.js'
+export * from './core/managed-agent-runner.js'
 export * from './email/email-rules-adapter.js'
 export * from './email/email-reply-adapter.js'


### PR DESCRIPTION
## What
Ports the missing OSS eval code into `gal/sdks/evals` (15 files, +1048): prediction-file adapter, managed-agent runner, report-submitter, `gal.evals.predictions.v1` types, 3 JSON schemas, a fixture, the CLI `--predictions`/`--submit-token-env` flags, and docs.

## Why
Verifier-confirmed absent from both monorepos — these landed ONLY on an unmerged branch of the archived `gal-evals-private` (not an ancestor of the HEAD that became `gal/sdks/evals`). Kept intentionally LLM-free/deterministic.

## Verification
`bun test` → **19 pass, 0 fail**. Secret scan clean (only env-var token-handling code; no values).

Part of #453. Surfaced by the archived-repo disposition audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Addresses #453
