### PR TITLE
mcp/chrome: port browser-use server build-out (10 tools) + Python service + test [ci]

### DIFF
--- a/mcp/chrome/README.md
+++ b/mcp/chrome/README.md
@@ -23,6 +23,24 @@ npm run build
 - `chrome_extension_clear_highlight` — Remove the automation overlay from the active tab
 - `chrome_extension_close` — Close the browser context and release the session
 
+### Browser-use build-out tools
+
+These drive the extension's `chrome.*` background APIs (with Playwright
+fallbacks where noted), plus two tools that delegate to the companion
+browser-use Python service (`mcp/gal-browser-use-service`, default
+`http://127.0.0.1:8123`, overridable via `GAL_BROWSER_USE_SERVICE_URL`).
+
+- `chrome_extension_tabGroups_create` — Create a tab group from tab IDs
+- `chrome_extension_tabGroups_list` — List tab groups in the current window
+- `chrome_extension_tabs_query` — Query tabs matching criteria
+- `chrome_extension_tabs_create` — Create a new tab (Playwright fallback)
+- `chrome_extension_tabs_remove` — Close one or more tabs by ID
+- `chrome_extension_bookmarks_search` — Search bookmarks by query
+- `chrome_extension_history_search` — Search browser history by text
+- `chrome_extension_windows_create` — Create a new browser window (Playwright fallback)
+- `chrome_extension_agent_run` — Run a browser-use agent task via the Python service
+- `chrome_extension_enhanced_parse` — Get enhanced DOM + AX tree via the Python service
+
 ## Security
 
 This server drives a real browser on behalf of a caller, so navigation

--- a/mcp/chrome/package.json
+++ b/mcp/chrome/package.json
@@ -17,6 +17,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "publishConfig": {
@@ -29,7 +30,8 @@
   "devDependencies": {
     "@types/node": "^22.10.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.0.16"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/mcp/chrome/src/server.ts
+++ b/mcp/chrome/src/server.ts
@@ -182,6 +182,181 @@ const CHROME_EXTENSION_GAL_TOOLS = [
       properties: {},
     },
   },
+  {
+    name: "chrome_extension_tabGroups_create",
+    description: "Create a tab group from the specified tab IDs.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tabIds: {
+          type: "array",
+          items: { type: "number" },
+          description: "Array of tab IDs to group",
+        },
+        title: {
+          type: "string",
+          description: "Optional title for the tab group",
+        },
+        color: {
+          type: "string",
+          description:
+            "Optional color for the tab group (e.g., grey, blue, red, yellow, green, pink, purple, cyan)",
+        },
+      },
+      required: ["tabIds"],
+    },
+  },
+  {
+    name: "chrome_extension_tabGroups_list",
+    description: "List all tab groups in the current window.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "chrome_extension_tabs_query",
+    description: "Query tabs matching the given criteria.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        active: {
+          type: "boolean",
+          description: "Whether the tab is active",
+        },
+        currentWindow: {
+          type: "boolean",
+          description: "Whether the tab is in the current window",
+        },
+        url: {
+          type: "string",
+          description: "Match tabs with this URL or URL pattern",
+        },
+      },
+    },
+  },
+  {
+    name: "chrome_extension_tabs_create",
+    description: "Create a new browser tab.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: {
+          type: "string",
+          description: "URL to open in the new tab",
+        },
+        active: {
+          type: "boolean",
+          description:
+            "Whether the new tab should become active (default: true)",
+        },
+      },
+      required: ["url"],
+    },
+  },
+  {
+    name: "chrome_extension_tabs_remove",
+    description: "Close one or more tabs by their IDs.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        tabIds: {
+          type: "array",
+          items: { type: "number" },
+          description: "Array of tab IDs to close",
+        },
+      },
+      required: ["tabIds"],
+    },
+  },
+  {
+    name: "chrome_extension_bookmarks_search",
+    description: "Search bookmarks by query string.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description: "Text to search for in bookmarks",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "chrome_extension_history_search",
+    description: "Search browser history by text.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        text: {
+          type: "string",
+          description: "Text to search for in history",
+        },
+        maxResults: {
+          type: "number",
+          description: "Maximum number of results to return (default: 100)",
+        },
+      },
+      required: ["text"],
+    },
+  },
+  {
+    name: "chrome_extension_windows_create",
+    description: "Create a new browser window.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: {
+          type: "string",
+          description: "Optional URL to open in the new window",
+        },
+        type: {
+          type: "string",
+          description: "Window type: normal, popup, panel, or app",
+        },
+      },
+    },
+  },
+  {
+    name: "chrome_extension_agent_run",
+    description:
+      "Run a browser-use agent task via the Python service (default: http://127.0.0.1:8123).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        task: {
+          type: "string",
+          description: "Natural language task description for the agent",
+        },
+        start_url: {
+          type: "string",
+          description: "Optional starting URL for the agent",
+        },
+        max_steps: {
+          type: "number",
+          description:
+            "Maximum number of steps the agent may take (default: 50)",
+        },
+      },
+      required: ["task"],
+    },
+  },
+  {
+    name: "chrome_extension_enhanced_parse",
+    description:
+      "Get enhanced DOM + accessibility tree via the Python service (default: http://127.0.0.1:8123).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        url: {
+          type: "string",
+          description: "URL to parse",
+        },
+      },
+      required: ["url"],
+    },
+  },
 ] as const;
 
 function toJsonContent(payload: unknown) {
@@ -193,6 +368,18 @@ function toJsonContent(payload: unknown) {
       },
     ],
   };
+}
+
+/**
+ * Base URL of the companion browser-use Python service that backs the
+ * agent_run and enhanced_parse tools (see mcp/gal-browser-use-service).
+ * Defaults to the loopback service the README documents; overridable via
+ * GAL_BROWSER_USE_SERVICE_URL so deployments can point at a co-located host.
+ */
+function browserUseServiceUrl(): string {
+  const raw = process.env.GAL_BROWSER_USE_SERVICE_URL;
+  const url = raw && raw.length > 0 ? raw : "http://127.0.0.1:8123";
+  return url.replace(/\/+$/, "");
 }
 
 /**
@@ -1340,6 +1527,419 @@ export function createChromeExtensionGalServer(
         case "chrome_extension_close": {
           await closeSession();
           return toJsonContent({ success: true });
+        }
+
+        case "chrome_extension_tabGroups_create": {
+          const activeSession = await getSession();
+          const tabIds = Array.isArray(safeArgs.tabIds)
+            ? (safeArgs.tabIds as number[])
+            : [];
+          if (tabIds.length === 0) {
+            throw new Error("tabIds is required and must be a non-empty array");
+          }
+          const title =
+            typeof safeArgs.title === "string" ? safeArgs.title : undefined;
+          const color =
+            typeof safeArgs.color === "string" ? safeArgs.color : undefined;
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let result: { groupId?: number } = {};
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const groupResult = await bp.evaluate(
+                async ([ids, t, c]) => {
+                  const api = (globalThis as any).chrome || (self as any).chrome;
+                  if (!api?.tabs?.group) return null;
+                  const groupId = await api.tabs.group({ tabIds: ids });
+                  if (t || c) {
+                    await api.tabGroups.update(groupId, {
+                      ...(t ? { title: t } : {}),
+                      ...(c ? { color: c } : {}),
+                      collapsed: false,
+                    });
+                  }
+                  return { groupId };
+                },
+                [tabIds, title, color] as const,
+              );
+              if (groupResult) {
+                result = groupResult;
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            throw new Error(
+              "tabGroups_create failed: Chrome extension APIs unavailable.",
+            );
+          }
+
+          return toJsonContent({
+            success: true,
+            groupId: result.groupId,
+            title,
+            color,
+          });
+        }
+
+        case "chrome_extension_tabGroups_list": {
+          const activeSession = await getSession();
+          const bgPages = activeSession.context.serviceWorkers();
+          let groups: unknown[] = [];
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const listResult = await bp.evaluate(async () => {
+                const api = (globalThis as any).chrome || (self as any).chrome;
+                if (!api?.tabGroups?.query) return null;
+                return await api.tabGroups.query({});
+              });
+              if (listResult) {
+                groups = listResult as unknown[];
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            throw new Error(
+              "tabGroups_list failed: Chrome extension APIs unavailable.",
+            );
+          }
+
+          return toJsonContent({ success: true, groups });
+        }
+
+        case "chrome_extension_tabs_query": {
+          const activeSession = await getSession();
+          const query: Record<string, unknown> = {};
+          if (typeof safeArgs.active === "boolean")
+            query.active = safeArgs.active;
+          if (typeof safeArgs.currentWindow === "boolean")
+            query.currentWindow = safeArgs.currentWindow;
+          if (typeof safeArgs.url === "string") query.url = safeArgs.url;
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let tabs: unknown[] = [];
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const queryResult = await bp.evaluate(async (q) => {
+                const api = (globalThis as any).chrome || (self as any).chrome;
+                if (!api?.tabs?.query) return null;
+                return await api.tabs.query(q);
+              }, query);
+              if (queryResult) {
+                tabs = queryResult as unknown[];
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            throw new Error(
+              "tabs_query failed: Chrome extension APIs unavailable.",
+            );
+          }
+
+          return toJsonContent({ success: true, tabs });
+        }
+
+        case "chrome_extension_tabs_create": {
+          const activeSession = await getSession();
+          const url = typeof safeArgs.url === "string" ? safeArgs.url : "";
+          if (!url) throw new Error("url is required");
+          const active = safeArgs.active !== false;
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let tab: unknown = null;
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const createResult = await bp.evaluate(
+                async ([u, a]) => {
+                  const api = (globalThis as any).chrome || (self as any).chrome;
+                  if (!api?.tabs?.create) return null;
+                  return await api.tabs.create({ url: u, active: a });
+                },
+                [url, active] as const,
+              );
+              if (createResult) {
+                tab = createResult;
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            // Fallback: open via Playwright page. Route through the same SSRF
+            // validation + network guard the rest of the server enforces.
+            const navigableUrl = await assertNavigableUrl(url, safeArgs);
+            await applySsrfPolicy(activeSession.context, safeArgs);
+            const newPage = await activeSession.context.newPage();
+            await newPage.goto(navigableUrl, { waitUntil: "domcontentloaded" });
+            activeSession.currentPage = newPage;
+            tab = { id: null, url: newPage.url(), active: true };
+          }
+
+          return toJsonContent({ success: true, tab });
+        }
+
+        case "chrome_extension_tabs_remove": {
+          const activeSession = await getSession();
+          const tabIds = Array.isArray(safeArgs.tabIds)
+            ? (safeArgs.tabIds as number[])
+            : [];
+          if (tabIds.length === 0) {
+            throw new Error("tabIds is required and must be a non-empty array");
+          }
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              await bp.evaluate(async (ids) => {
+                const api = (globalThis as any).chrome || (self as any).chrome;
+                if (!api?.tabs?.remove) return false;
+                await api.tabs.remove(ids);
+                return true;
+              }, tabIds);
+              success = true;
+              break;
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            throw new Error(
+              "tabs_remove failed: Chrome extension APIs unavailable.",
+            );
+          }
+
+          return toJsonContent({ success: true, removed: tabIds });
+        }
+
+        case "chrome_extension_bookmarks_search": {
+          const activeSession = await getSession();
+          const query =
+            typeof safeArgs.query === "string" ? safeArgs.query : "";
+          if (!query) throw new Error("query is required");
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let results: unknown[] = [];
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const searchResult = await bp.evaluate(async (q) => {
+                const api = (globalThis as any).chrome || (self as any).chrome;
+                if (!api?.bookmarks?.search) return null;
+                return await api.bookmarks.search(q);
+              }, query);
+              if (searchResult) {
+                results = searchResult as unknown[];
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            throw new Error(
+              "bookmarks_search failed: Chrome extension APIs unavailable.",
+            );
+          }
+
+          return toJsonContent({ success: true, results });
+        }
+
+        case "chrome_extension_history_search": {
+          const activeSession = await getSession();
+          const text = typeof safeArgs.text === "string" ? safeArgs.text : "";
+          if (!text) throw new Error("text is required");
+          const maxResults =
+            typeof safeArgs.maxResults === "number" ? safeArgs.maxResults : 100;
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let results: unknown[] = [];
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const searchResult = await bp.evaluate(
+                async ([t, m]) => {
+                  const api = (globalThis as any).chrome || (self as any).chrome;
+                  if (!api?.history?.search) return null;
+                  return await api.history.search({
+                    text: t,
+                    maxResults: m,
+                  });
+                },
+                [text, maxResults] as const,
+              );
+              if (searchResult) {
+                results = searchResult as unknown[];
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            throw new Error(
+              "history_search failed: Chrome extension APIs unavailable.",
+            );
+          }
+
+          return toJsonContent({ success: true, results });
+        }
+
+        case "chrome_extension_windows_create": {
+          const activeSession = await getSession();
+          const url =
+            typeof safeArgs.url === "string" ? safeArgs.url : undefined;
+          const type =
+            typeof safeArgs.type === "string" ? safeArgs.type : undefined;
+
+          const bgPages = activeSession.context.serviceWorkers();
+          let win: unknown = null;
+          let success = false;
+
+          for (const bp of bgPages) {
+            try {
+              const createResult = await bp.evaluate(
+                async ([u, t]) => {
+                  const api = (globalThis as any).chrome || (self as any).chrome;
+                  if (!api?.windows?.create) return null;
+                  const opts: Record<string, unknown> = {};
+                  if (u) opts.url = u;
+                  if (t) opts.type = t;
+                  return await api.windows.create(opts);
+                },
+                [url, type] as const,
+              );
+              if (createResult) {
+                win = createResult;
+                success = true;
+                break;
+              }
+            } catch {
+              /* try next bg page */
+            }
+          }
+
+          if (!success) {
+            // Fallback: open via Playwright context new page. Route any URL
+            // through the same SSRF validation + network guard.
+            const newPage = await activeSession.context.newPage();
+            if (url) {
+              const navigableUrl = await assertNavigableUrl(url, safeArgs);
+              await applySsrfPolicy(activeSession.context, safeArgs);
+              await newPage.goto(navigableUrl, {
+                waitUntil: "domcontentloaded",
+              });
+            }
+            activeSession.currentPage = newPage;
+            win = { id: null, tabs: [{ url: newPage.url() }] };
+          }
+
+          return toJsonContent({ success: true, window: win });
+        }
+
+        case "chrome_extension_agent_run": {
+          const task = typeof safeArgs.task === "string" ? safeArgs.task : "";
+          if (!task) throw new Error("task is required");
+          const startUrl =
+            typeof safeArgs.start_url === "string"
+              ? safeArgs.start_url
+              : undefined;
+          const maxSteps =
+            typeof safeArgs.max_steps === "number" ? safeArgs.max_steps : 50;
+
+          const payload: Record<string, unknown> = {
+            task,
+            max_steps: maxSteps,
+          };
+          if (startUrl) payload.start_url = startUrl;
+
+          const serviceUrl = browserUseServiceUrl();
+          let response: Response;
+          try {
+            response = await fetch(`${serviceUrl}/agent/run`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+          } catch (fetchErr: unknown) {
+            throw new Error(
+              `agent_run failed to connect to ${serviceUrl}: ${
+                fetchErr instanceof Error ? fetchErr.message : String(fetchErr)
+              }`,
+            );
+          }
+
+          if (!response.ok) {
+            throw new Error(
+              `agent_run service returned ${response.status}: ${await response.text()}`,
+            );
+          }
+
+          const data = await response.json();
+          return toJsonContent({ success: true, ...data });
+        }
+
+        case "chrome_extension_enhanced_parse": {
+          const url = typeof safeArgs.url === "string" ? safeArgs.url : "";
+          if (!url) throw new Error("url is required");
+
+          const serviceUrl = browserUseServiceUrl();
+          let response: Response;
+          try {
+            response = await fetch(`${serviceUrl}/dom/enhanced-parse`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ url }),
+            });
+          } catch (fetchErr: unknown) {
+            throw new Error(
+              `enhanced_parse failed to connect to ${serviceUrl}: ${
+                fetchErr instanceof Error ? fetchErr.message : String(fetchErr)
+              }`,
+            );
+          }
+
+          if (!response.ok) {
+            throw new Error(
+              `enhanced_parse service returned ${response.status}: ${await response.text()}`,
+            );
+          }
+
+          const data = await response.json();
+          return toJsonContent({ success: true, ...data });
         }
 
         default:

--- a/mcp/chrome/src/server.ts
+++ b/mcp/chrome/src/server.ts
@@ -1717,14 +1717,16 @@ export function createChromeExtensionGalServer(
 
           for (const bp of bgPages) {
             try {
-              await bp.evaluate(async (ids) => {
+              const removeResult = await bp.evaluate(async (ids) => {
                 const api = (globalThis as any).chrome || (self as any).chrome;
                 if (!api?.tabs?.remove) return false;
                 await api.tabs.remove(ids);
                 return true;
               }, tabIds);
-              success = true;
-              break;
+              if (removeResult) {
+                success = true;
+                break;
+              }
             } catch {
               /* try next bg page */
             }

--- a/mcp/chrome/test/unified-system.test.ts
+++ b/mcp/chrome/test/unified-system.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unified GAL Browser System Integration Tests
+ *
+ * Tests the full pipeline:
+ *   1. Chrome extension enhanced DOM scanner
+ *   2. Python browser-use service (mcp/gal-browser-use-service)
+ *   3. MCP Chrome API tools (mcp/chrome)
+ *
+ * Ported from gal-run/gal-browser-use-mcp PR #2
+ * (branch feat/server-impl-and-tests).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+
+const SERVICE_URL =
+  process.env.GAL_BROWSER_USE_SERVICE_URL ?? "http://127.0.0.1:8123";
+const TEST_URL = "https://example.com";
+
+async function serviceHealth(): Promise<boolean> {
+  try {
+    const res = await fetch(`${SERVICE_URL}/health`, { method: "POST" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// The integration suite needs the companion Python service running on
+// port 8123. When it is not available we skip rather than fail so the
+// package's unit checks (the static tool-definition check below) still run
+// in CI without the service.
+const serviceUp = await serviceHealth();
+const describeService = serviceUp ? describe : describe.skip;
+
+describe("Unified GAL Browser System", () => {
+  describeService("Python Service", () => {
+    beforeAll(async () => {
+      const ok = await serviceHealth();
+      if (!ok) {
+        throw new Error(
+          "Python browser-use service is not running on port 8123. " +
+            "Start it first: cd mcp/gal-browser-use-service && ./start.sh",
+        );
+      }
+    });
+
+    it("health endpoint returns ok", async () => {
+      const res = await fetch(`${SERVICE_URL}/health`, { method: "POST" });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("ok");
+    });
+
+    it("dom/enhanced-parse returns elements for example.com", async () => {
+      const res = await fetch(`${SERVICE_URL}/dom/enhanced-parse`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: TEST_URL }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.url).toBe(TEST_URL);
+      expect(Array.isArray(body.elements)).toBe(true);
+      expect(body.elements.length).toBeGreaterThan(0);
+      // Verify browser-use AX metadata is present
+      const first = body.elements[0];
+      expect(first).toHaveProperty("tag");
+      expect(first).toHaveProperty("role");
+      expect(first).toHaveProperty("xpath");
+    });
+
+    it("cache round-trip works", async () => {
+      const siteHash = "test-site-123";
+      const actions = [{ type: "click", index: 1 }];
+
+      // Store
+      const storeRes = await fetch(`${SERVICE_URL}/cache/${siteHash}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ actions }),
+      });
+      expect(storeRes.status).toBe(200);
+
+      // Retrieve
+      const getRes = await fetch(`${SERVICE_URL}/cache/${siteHash}`);
+      expect(getRes.status).toBe(200);
+      const body = await getRes.json();
+      expect(body.actions).toEqual(actions);
+
+      // Delete
+      const delRes = await fetch(`${SERVICE_URL}/cache/${siteHash}`, {
+        method: "DELETE",
+      });
+      expect(delRes.status).toBe(200);
+
+      // Verify deleted
+      const verifyRes = await fetch(`${SERVICE_URL}/cache/${siteHash}`);
+      expect(verifyRes.status).toBe(404);
+    });
+  });
+
+  describe("MCP Server Tools (unit check)", () => {
+    it("has all 10 new tool definitions", async () => {
+      // This is a static check — the server.ts file should contain all tools.
+      const { readFileSync } = await import("fs");
+      const { fileURLToPath } = await import("url");
+      const { dirname, resolve } = await import("path");
+      const here = dirname(fileURLToPath(import.meta.url));
+      const serverSrc = readFileSync(
+        resolve(here, "..", "src", "server.ts"),
+        "utf-8",
+      );
+      const expectedTools = [
+        "chrome_extension_tabGroups_create",
+        "chrome_extension_tabGroups_list",
+        "chrome_extension_tabs_query",
+        "chrome_extension_tabs_create",
+        "chrome_extension_tabs_remove",
+        "chrome_extension_bookmarks_search",
+        "chrome_extension_history_search",
+        "chrome_extension_windows_create",
+        "chrome_extension_agent_run",
+        "chrome_extension_enhanced_parse",
+      ];
+      for (const name of expectedTools) {
+        expect(serverSrc).toContain(name);
+      }
+    });
+  });
+});

--- a/mcp/chrome/vitest.config.ts
+++ b/mcp/chrome/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    testTimeout: 30000,
+  },
+});

--- a/mcp/gal-browser-use-service/.gitignore
+++ b/mcp/gal-browser-use-service/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+*.db

--- a/mcp/gal-browser-use-service/Dockerfile
+++ b/mcp/gal-browser-use-service/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1
+# Multi-stage build for the GAL Browser Use Service.
+# Pre-installs Playwright browsers so the container is ready to run headfully or headlessly.
+
+# ---------------------------------------------------------------------------
+# Builder — compile Python dependencies
+# ---------------------------------------------------------------------------
+FROM python:3.14-slim AS builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --user -r requirements.txt
+
+# ---------------------------------------------------------------------------
+# Runtime — Playwright + extension + app
+# ---------------------------------------------------------------------------
+FROM python:3.14-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    BROWSER_USE_DB=/data/browser_use_cache.db \
+    CHROME_EXTENSION_PATH=/app/gal-extension \
+    PATH="/root/.local/bin:${PATH}"
+
+# System deps for Chromium + Playwright
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libatspi2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy pre-built wheels from builder
+COPY --from=builder /root/.local /root/.local
+
+# Install Playwright browsers (Chromium only to keep image size down)
+RUN pip install --no-cache-dir playwright && \
+    playwright install chromium && \
+    playwright install-deps chromium
+
+WORKDIR /app
+
+# Application code
+COPY main.py chrome_bridge.py ./
+
+# Placeholder for the GAL Chrome extension (mounted or copied at build time)
+RUN mkdir -p /app/gal-extension
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/mcp/gal-browser-use-service/Dockerfile
+++ b/mcp/gal-browser-use-service/Dockerfile
@@ -5,7 +5,7 @@
 # ---------------------------------------------------------------------------
 # Builder — compile Python dependencies
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim AS builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /build
 
@@ -20,13 +20,15 @@ RUN pip install --no-cache-dir --user -r requirements.txt
 # ---------------------------------------------------------------------------
 # Runtime — Playwright + extension + app
 # ---------------------------------------------------------------------------
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     BROWSER_USE_DB=/data/browser_use_cache.db \
     CHROME_EXTENSION_PATH=/app/gal-extension \
+    HOST=127.0.0.1 \
+    PORT=8123 \
     PATH="/root/.local/bin:${PATH}"
 
 # System deps for Chromium + Playwright
@@ -48,12 +50,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libatspi2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy pre-built wheels from builder
+# Copy pre-built wheels from builder (includes playwright from requirements.txt)
 COPY --from=builder /root/.local /root/.local
 
-# Install Playwright browsers (Chromium only to keep image size down)
-RUN pip install --no-cache-dir playwright && \
-    playwright install chromium && \
+# Install Playwright browser binaries (Chromium only to keep image size down)
+RUN playwright install chromium && \
     playwright install-deps chromium
 
 WORKDIR /app
@@ -64,6 +65,7 @@ COPY main.py chrome_bridge.py ./
 # Placeholder for the GAL Chrome extension (mounted or copied at build time)
 RUN mkdir -p /app/gal-extension
 
-EXPOSE 8000
+EXPOSE 8123
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Bind to localhost by default; override HOST/PORT (e.g. HOST=0.0.0.0) to expose.
+CMD ["sh", "-c", "uvicorn main:app --host \"$HOST\" --port \"$PORT\""]

--- a/mcp/gal-browser-use-service/README.md
+++ b/mcp/gal-browser-use-service/README.md
@@ -1,0 +1,73 @@
+# GAL Browser Use Service
+
+A FastAPI microservice that wraps [browser-use](https://github.com/browser-use/browser-use) with a bridge to the GAL Chrome extension.
+
+## Features
+
+- **Agent execution** — run high-level tasks via `POST /agent/run` using browser-use's Agent + Playwright
+- **Enhanced DOM parsing** — retrieve structured element lists with AX tree metadata via `POST /dom/enhanced-parse`
+- **Action caching** — SQLite-backed cache for per-site action sequences (`/cache/{site_hash}`)
+- **Chrome extension bridge** — `chrome_bridge.py` stubs for tabs, tabGroups, and bookmarks (wire to the extension's HTTP endpoint when ready)
+
+## Quick Start (local)
+
+```bash
+cd mcp/gal-browser-use-service
+python3.14 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+playwright install chromium
+
+# Optional: set env vars
+export EXTENSION_BRIDGE_URL=http://localhost:9222
+export CHROME_EXTENSION_PATH=/path/to/gal-extension
+
+uvicorn main:app --reload --port 8000
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/health` | Health check |
+| POST | `/agent/run` | Run a browser-use Agent |
+| POST | `/dom/enhanced-parse` | Parse enhanced DOM + AX tree |
+| GET | `/cache/{site_hash}` | Get cached actions |
+| POST | `/cache/{site_hash}` | Store cached actions |
+| DELETE | `/cache/{site_hash}` | Clear cached actions |
+
+### Example: run an agent
+
+```bash
+curl -X POST http://localhost:8000/agent/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Find the pricing page and extract the starter plan price",
+    "model": "gpt-4o",
+    "max_steps": 15,
+    "start_url": "https://example.com"
+  }'
+```
+
+### Example: enhanced DOM parse
+
+```bash
+curl -X POST http://localhost:8000/dom/enhanced-parse \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Docker
+
+```bash
+docker build -t gal-browser-use-service .
+docker run -p 8000:8000 -v /path/to/gal-extension:/app/gal-extension gal-browser-use-service
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BROWSER_USE_DB` | `/tmp/browser_use_cache.db` | SQLite cache path |
+| `EXTENSION_BRIDGE_URL` | `http://localhost:9222` | GAL extension HTTP bridge |
+| `CHROME_EXTENSION_PATH` | `/app/gal-extension` | Path to the unpacked extension |

--- a/mcp/gal-browser-use-service/README.md
+++ b/mcp/gal-browser-use-service/README.md
@@ -13,7 +13,7 @@ A FastAPI microservice that wraps [browser-use](https://github.com/browser-use/b
 
 ```bash
 cd mcp/gal-browser-use-service
-python3.14 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 playwright install chromium
@@ -22,7 +22,7 @@ playwright install chromium
 export EXTENSION_BRIDGE_URL=http://localhost:9222
 export CHROME_EXTENSION_PATH=/path/to/gal-extension
 
-uvicorn main:app --reload --port 8000
+uvicorn main:app --reload --host 127.0.0.1 --port 8123
 ```
 
 ## Endpoints
@@ -39,8 +39,9 @@ uvicorn main:app --reload --port 8000
 ### Example: run an agent
 
 ```bash
-curl -X POST http://localhost:8000/agent/run \
+curl -X POST http://localhost:8123/agent/run \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $SERVICE_AUTH_TOKEN" \
   -d '{
     "task": "Find the pricing page and extract the starter plan price",
     "model": "gpt-4o",
@@ -52,8 +53,9 @@ curl -X POST http://localhost:8000/agent/run \
 ### Example: enhanced DOM parse
 
 ```bash
-curl -X POST http://localhost:8000/dom/enhanced-parse \
+curl -X POST http://localhost:8123/dom/enhanced-parse \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $SERVICE_AUTH_TOKEN" \
   -d '{"url": "https://example.com"}'
 ```
 
@@ -61,7 +63,8 @@ curl -X POST http://localhost:8000/dom/enhanced-parse \
 
 ```bash
 docker build -t gal-browser-use-service .
-docker run -p 8000:8000 -v /path/to/gal-extension:/app/gal-extension gal-browser-use-service
+# The container binds 127.0.0.1 by default; set HOST=0.0.0.0 to expose the port.
+docker run -e HOST=0.0.0.0 -p 8123:8123 -v /path/to/gal-extension:/app/gal-extension gal-browser-use-service
 ```
 
 ## Environment Variables
@@ -71,3 +74,7 @@ docker run -p 8000:8000 -v /path/to/gal-extension:/app/gal-extension gal-browser
 | `BROWSER_USE_DB` | `/tmp/browser_use_cache.db` | SQLite cache path |
 | `EXTENSION_BRIDGE_URL` | `http://localhost:9222` | GAL extension HTTP bridge |
 | `CHROME_EXTENSION_PATH` | `/app/gal-extension` | Path to the unpacked extension |
+| `SERVICE_AUTH_TOKEN` | _(unset)_ | If set, `/agent/run` and `/dom/enhanced-parse` require `Authorization: Bearer <token>`. Unset = dev mode (no auth, logs a warning). |
+| `GAL_BROWSER_ALLOW_PRIVATE` | _(unset)_ | Set to `1` to bypass the SSRF guard and allow navigation to private/loopback/link-local hosts. |
+| `HOST` | `127.0.0.1` | Bind address (Docker `CMD`). Set to `0.0.0.0` to expose. |
+| `PORT` | `8123` | Bind port (Docker `CMD`). |

--- a/mcp/gal-browser-use-service/chrome_bridge.py
+++ b/mcp/gal-browser-use-service/chrome_bridge.py
@@ -1,0 +1,90 @@
+"""HTTP client for the GAL Chrome extension service worker."""
+
+import httpx
+from typing import Any, Optional
+
+DEFAULT_EXTENSION_URL = "http://localhost:9222"
+
+
+class ChromeBridge:
+    """Bridge to the GAL Chrome extension via HTTP.
+
+    The extension exposes a lightweight HTTP endpoint (e.g. a service worker
+    fetch handler or a tiny background page server) so that external agents
+    can call Chrome APIs without running inside the browser.
+    """
+
+    def __init__(self, base_url: str = DEFAULT_EXTENSION_URL):
+        self.base_url = base_url.rstrip("/")
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self.base_url, timeout=30.0)
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Tabs
+    # ------------------------------------------------------------------
+
+    async def tabs_query(self, query_info: dict[str, Any]) -> list[dict[str, Any]]:
+        """Query Chrome tabs."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("tabs_query is stubbed — wire to extension endpoint")
+
+    async def tabs_create(self, create_properties: dict[str, Any]) -> dict[str, Any]:
+        """Create a new tab."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("tabs_create is stubbed — wire to extension endpoint")
+
+    async def tabs_update(self, tab_id: int, update_properties: dict[str, Any]) -> dict[str, Any]:
+        """Update a tab."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("tabs_update is stubbed — wire to extension endpoint")
+
+    async def tabs_remove(self, tab_ids: list[int]) -> None:
+        """Close one or more tabs."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("tabs_remove is stubbed — wire to extension endpoint")
+
+    # ------------------------------------------------------------------
+    # Tab Groups
+    # ------------------------------------------------------------------
+
+    async def tabGroups_query(self, query_info: dict[str, Any]) -> list[dict[str, Any]]:
+        """Query tab groups."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("tabGroups_query is stubbed — wire to extension endpoint")
+
+    async def tabGroups_update(self, group_id: int, update_properties: dict[str, Any]) -> dict[str, Any]:
+        """Update a tab group."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("tabGroups_update is stubbed — wire to extension endpoint")
+
+    # ------------------------------------------------------------------
+    # Bookmarks
+    # ------------------------------------------------------------------
+
+    async def bookmarks_getTree(self) -> list[dict[str, Any]]:
+        """Get the full bookmarks tree."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("bookmarks_getTree is stubbed — wire to extension endpoint")
+
+    async def bookmarks_create(self, bookmark: dict[str, Any]) -> dict[str, Any]:
+        """Create a bookmark or folder."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("bookmarks_create is stubbed — wire to extension endpoint")
+
+    async def bookmarks_remove(self, id: str) -> None:
+        """Remove a bookmark."""
+        # TODO: implement once extension HTTP endpoint is ready
+        raise NotImplementedError("bookmarks_remove is stubbed — wire to extension endpoint")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None

--- a/mcp/gal-browser-use-service/main.py
+++ b/mcp/gal-browser-use-service/main.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 import aiosqlite
@@ -40,6 +42,8 @@ class AgentRunResponse(BaseModel):
     success: bool
     result: str
     steps_taken: int
+    gif_path: str | None = None
+    video_path: str | None = None
 
 class DOMEnhancedParseRequest(BaseModel):
     url: str
@@ -161,9 +165,15 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
         "--disable-setuid-sandbox",
     ]
 
+    # Replay capture (video evidence): annotated GIF + Playwright session video.
+    replay_dir = Path(os.getenv("REPLAY_OUTPUT_DIR", "/tmp/gal-replays")) / uuid.uuid4().hex
+    replay_dir.mkdir(parents=True, exist_ok=True)
+    gif_path = replay_dir / "run.gif"
+
     browser = BrowserSession(
         headless=False,
         args=extra_chromium_args,
+        record_video_dir=str(replay_dir),
     )
     await browser.start()
 
@@ -174,6 +184,7 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
         llm=llm,
         browser_session=browser,
         use_vision=True,
+        generate_gif=str(gif_path),
     )
 
     try:
@@ -186,10 +197,13 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
     await browser.close()
     await bridge.close()
 
+    videos = sorted(str(p) for p in replay_dir.glob("*.webm"))
     return AgentRunResponse(
         success=True,
         result=str(result),
         steps_taken=getattr(agent, "steps_taken", 0),
+        gif_path=str(gif_path) if gif_path.exists() else None,
+        video_path=videos[0] if videos else None,
     )
 
 @app.post("/dom/enhanced-parse", response_model=DOMEnhancedParseResponse)

--- a/mcp/gal-browser-use-service/main.py
+++ b/mcp/gal-browser-use-service/main.py
@@ -3,18 +3,24 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
+import logging
 import os
+import socket
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import aiosqlite
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from chrome_bridge import ChromeBridge
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -23,6 +29,14 @@ from chrome_bridge import ChromeBridge
 DB_PATH = os.getenv("BROWSER_USE_DB", "/tmp/browser_use_cache.db")
 EXTENSION_URL = os.getenv("EXTENSION_BRIDGE_URL", "http://localhost:9222")
 CHROME_EXTENSION_PATH = os.getenv("CHROME_EXTENSION_PATH", "/app/gal-extension")
+
+# Bearer-token guard for mutating/navigation endpoints. When unset, the service
+# runs in dev mode (no auth) and logs a warning.
+SERVICE_AUTH_TOKEN = os.getenv("SERVICE_AUTH_TOKEN")
+
+# SSRF guard: by default, block navigation to private/loopback/link-local hosts.
+# Opt out (e.g. for trusted internal targets) with GAL_BROWSER_ALLOW_PRIVATE=1.
+ALLOW_PRIVATE_HOSTS = os.getenv("GAL_BROWSER_ALLOW_PRIVATE") == "1"
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -130,6 +144,73 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="GAL Browser Use Service", lifespan=lifespan)
 
 # ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+async def require_auth(authorization: str | None = Header(default=None)) -> None:
+    """Bearer-token guard for navigation endpoints.
+
+    If SERVICE_AUTH_TOKEN is set, require `Authorization: Bearer <token>` and
+    401 on mismatch. If unset, allow (dev) but log a warning.
+    """
+    if not SERVICE_AUTH_TOKEN:
+        logger.warning(
+            "SERVICE_AUTH_TOKEN is unset; serving request without authentication (dev mode)."
+        )
+        return
+    scheme, _, token = (authorization or "").partition(" ")
+    if scheme.lower() != "bearer" or token != SERVICE_AUTH_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid or missing bearer token")
+
+# ---------------------------------------------------------------------------
+# SSRF guard
+# ---------------------------------------------------------------------------
+
+def assert_navigable_url(url: str) -> None:
+    """Validate a caller-supplied navigation URL against SSRF.
+
+    Require an http/https scheme; resolve the host and block private,
+    loopback, link-local, and metadata ranges unless GAL_BROWSER_ALLOW_PRIVATE=1.
+    Raises HTTPException(400) on violation.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="URL scheme must be http or https")
+    host = parsed.hostname
+    if not host:
+        raise HTTPException(status_code=400, detail="URL must include a host")
+
+    if ALLOW_PRIVATE_HOSTS:
+        return
+
+    try:
+        infos = socket.getaddrinfo(host, parsed.port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise HTTPException(status_code=400, detail=f"Could not resolve host: {exc}")
+
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        # Block private/loopback/link-local (incl. 169.254.169.254 metadata),
+        # plus IPv6 loopback (::1) and unique-local fc00::/7. is_private covers
+        # 10/8, 172.16/12, 192.168/16 and fc00::/7; is_link_local covers
+        # 169.254/16 and fe80::/10.
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Navigation to private/loopback/link-local host is blocked: {host} -> {addr}",
+            )
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -137,13 +218,16 @@ app = FastAPI(title="GAL Browser Use Service", lifespan=lifespan)
 async def health() -> HealthResponse:
     return HealthResponse(status="ok")
 
-@app.post("/agent/run", response_model=AgentRunResponse)
+@app.post("/agent/run", response_model=AgentRunResponse, dependencies=[Depends(require_auth)])
 async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
     """Run a browser-use Agent to execute *task*.
 
     The Agent is launched with Playwright and the GAL Chrome extension
     pre-loaded via `--load-extension` / `--disable-extensions-except`.
     """
+    if req.start_url is not None:
+        assert_navigable_url(req.start_url)
+
     try:
         from browser_use.agent.service import Agent
         from browser_use.browser.session import BrowserSession
@@ -188,7 +272,7 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
     )
 
     try:
-        result = await agent.run(max_steps=req.max_steps)
+        history = await agent.run(max_steps=req.max_steps)
     except Exception as exc:
         await browser.close()
         await bridge.close()
@@ -200,17 +284,23 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
     videos = sorted(str(p) for p in replay_dir.glob("*.webm"))
     return AgentRunResponse(
         success=True,
-        result=str(result),
-        steps_taken=getattr(agent, "steps_taken", 0),
+        result=history.final_result() or "",
+        steps_taken=history.number_of_steps(),
         gif_path=str(gif_path) if gif_path.exists() else None,
         video_path=videos[0] if videos else None,
     )
 
-@app.post("/dom/enhanced-parse", response_model=DOMEnhancedParseResponse)
+@app.post(
+    "/dom/enhanced-parse",
+    response_model=DOMEnhancedParseResponse,
+    dependencies=[Depends(require_auth)],
+)
 async def dom_enhanced_parse(req: DOMEnhancedParseRequest) -> DOMEnhancedParseResponse:
     """Navigate to *url*, retrieve the enhanced DOM + AX tree, and return
     a structured element list using browser-use's DOM parser.
     """
+    assert_navigable_url(req.url)
+
     try:
         from browser_use.browser.session import BrowserSession
         from browser_use.dom.service import DomService

--- a/mcp/gal-browser-use-service/main.py
+++ b/mcp/gal-browser-use-service/main.py
@@ -31,7 +31,7 @@ class HealthResponse(BaseModel):
 
 class AgentRunRequest(BaseModel):
     task: str
-    model: str = "gpt-4o"
+    model: str = "gemini-2.5-flash"  # cost default; override per-request
     max_steps: int = Field(default=10, ge=1, le=100)
     start_url: str | None = None
     extension_bridge_url: str | None = None
@@ -143,7 +143,7 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
     try:
         from browser_use.agent.service import Agent
         from browser_use.browser.session import BrowserSession
-        from browser_use.llm.models import ChatOpenAI
+        from browser_use.llm.models import ChatOpenAI, ChatGoogle
     except ImportError as exc:
         raise HTTPException(status_code=500, detail=f"browser-use not installed: {exc}")
 
@@ -167,7 +167,8 @@ async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
     )
     await browser.start()
 
-    llm = ChatOpenAI(model=req.model)
+    # Provider routing: Gemini Flash by default (cost), OpenAI still available on request.
+    llm = ChatGoogle(model=req.model) if req.model.startswith("gemini") else ChatOpenAI(model=req.model)
     agent = Agent(
         task=req.task,
         llm=llm,

--- a/mcp/gal-browser-use-service/main.py
+++ b/mcp/gal-browser-use-service/main.py
@@ -1,0 +1,261 @@
+"""FastAPI microservice wrapping browser-use with a Chrome extension bridge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from contextlib import asynccontextmanager
+from typing import Any
+
+import aiosqlite
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from chrome_bridge import ChromeBridge
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DB_PATH = os.getenv("BROWSER_USE_DB", "/tmp/browser_use_cache.db")
+EXTENSION_URL = os.getenv("EXTENSION_BRIDGE_URL", "http://localhost:9222")
+CHROME_EXTENSION_PATH = os.getenv("CHROME_EXTENSION_PATH", "/app/gal-extension")
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class HealthResponse(BaseModel):
+    status: str = "ok"
+
+class AgentRunRequest(BaseModel):
+    task: str
+    model: str = "gpt-4o"
+    max_steps: int = Field(default=10, ge=1, le=100)
+    start_url: str | None = None
+    extension_bridge_url: str | None = None
+
+class AgentRunResponse(BaseModel):
+    success: bool
+    result: str
+    steps_taken: int
+
+class DOMEnhancedParseRequest(BaseModel):
+    url: str
+
+class DOMElement(BaseModel):
+    tag: str
+    text: str | None = None
+    attributes: dict[str, str] = {}
+    xpath: str | None = None
+    role: str | None = None
+    aria_label: str | None = None
+
+class DOMEnhancedParseResponse(BaseModel):
+    url: str
+    title: str | None = None
+    elements: list[DOMElement]
+    element_count: int
+
+class CacheStoreRequest(BaseModel):
+    actions: list[dict[str, Any]]
+
+class CacheResponse(BaseModel):
+    site_hash: str
+    actions: list[dict[str, Any]] | None = None
+
+# ---------------------------------------------------------------------------
+# SQLite cache helpers
+# ---------------------------------------------------------------------------
+
+async def _init_db() -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS action_cache (
+                site_hash TEXT PRIMARY KEY,
+                actions   TEXT NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await db.commit()
+
+async def _get_cache(site_hash: str) -> list[dict[str, Any]] | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT actions FROM action_cache WHERE site_hash = ?", (site_hash,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            return json.loads(row[0])
+
+async def _set_cache(site_hash: str, actions: list[dict[str, Any]]) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT INTO action_cache(site_hash, actions)
+            VALUES (?, ?)
+            ON CONFLICT(site_hash) DO UPDATE SET
+                actions = excluded.actions,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (site_hash, json.dumps(actions)),
+        )
+        await db.commit()
+
+async def _delete_cache(site_hash: str) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM action_cache WHERE site_hash = ?", (site_hash,)
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+# ---------------------------------------------------------------------------
+# Lifespan
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await _init_db()
+    yield
+
+app = FastAPI(title="GAL Browser Use Service", lifespan=lifespan)
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@app.post("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    return HealthResponse(status="ok")
+
+@app.post("/agent/run", response_model=AgentRunResponse)
+async def agent_run(req: AgentRunRequest) -> AgentRunResponse:
+    """Run a browser-use Agent to execute *task*.
+
+    The Agent is launched with Playwright and the GAL Chrome extension
+    pre-loaded via `--load-extension` / `--disable-extensions-except`.
+    """
+    try:
+        from browser_use.agent.service import Agent
+        from browser_use.browser.session import BrowserSession
+        from browser_use.llm.models import ChatOpenAI
+    except ImportError as exc:
+        raise HTTPException(status_code=500, detail=f"browser-use not installed: {exc}")
+
+    bridge = ChromeBridge(
+        base_url=req.extension_bridge_url or EXTENSION_URL
+    )
+
+    # Build Playwright launch args so the GAL extension is loaded.
+    # These flags mirror the TypeScript MCP approach.
+    extension_path = CHROME_EXTENSION_PATH
+    extra_chromium_args = [
+        f"--disable-extensions-except={extension_path}",
+        f"--load-extension={extension_path}",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+    ]
+
+    browser = BrowserSession(
+        headless=False,
+        args=extra_chromium_args,
+    )
+    await browser.start()
+
+    llm = ChatOpenAI(model=req.model)
+    agent = Agent(
+        task=req.task,
+        llm=llm,
+        browser_session=browser,
+        use_vision=True,
+    )
+
+    try:
+        result = await agent.run(max_steps=req.max_steps)
+    except Exception as exc:
+        await browser.close()
+        await bridge.close()
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    await browser.close()
+    await bridge.close()
+
+    return AgentRunResponse(
+        success=True,
+        result=str(result),
+        steps_taken=getattr(agent, "steps_taken", 0),
+    )
+
+@app.post("/dom/enhanced-parse", response_model=DOMEnhancedParseResponse)
+async def dom_enhanced_parse(req: DOMEnhancedParseRequest) -> DOMEnhancedParseResponse:
+    """Navigate to *url*, retrieve the enhanced DOM + AX tree, and return
+    a structured element list using browser-use's DOM parser.
+    """
+    try:
+        from browser_use.browser.session import BrowserSession
+        from browser_use.dom.service import DomService
+    except ImportError as exc:
+        raise HTTPException(status_code=500, detail=f"browser-use not installed: {exc}")
+
+    browser = BrowserSession(
+        headless=True,
+        args=["--no-sandbox", "--disable-setuid-sandbox"],
+    )
+    await browser.start()
+
+    try:
+        await browser.navigate_to(req.url)
+        page = await browser.must_get_current_page()
+        title = await page.get_title()
+
+        dom_service = DomService(browser_session=browser)
+        state, _tree, _metrics = await dom_service.get_serialized_dom_tree()
+
+        elements: list[DOMElement] = []
+        for idx, node in state.selector_map.items():
+            elements.append(
+                DOMElement(
+                    tag=getattr(node, "tag_name", ""),
+                    text=getattr(node, "text", ""),
+                    attributes=getattr(node, "attributes", {}),
+                    xpath=getattr(node, "xpath", ""),
+                    role=getattr(node, "role", ""),
+                    aria_label=getattr(node, "attributes", {}).get("aria-label"),
+                )
+            )
+    except Exception as exc:
+        await browser.close()
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    await browser.close()
+
+    return DOMEnhancedParseResponse(
+        url=req.url,
+        title=title,
+        elements=elements,
+        element_count=len(elements),
+    )
+
+@app.get("/cache/{site_hash}", response_model=CacheResponse)
+async def cache_get(site_hash: str) -> CacheResponse:
+    actions = await _get_cache(site_hash)
+    if actions is None:
+        raise HTTPException(status_code=404, detail="Cache miss")
+    return CacheResponse(site_hash=site_hash, actions=actions)
+
+@app.post("/cache/{site_hash}", response_model=CacheResponse)
+async def cache_store(site_hash: str, req: CacheStoreRequest) -> CacheResponse:
+    await _set_cache(site_hash, req.actions)
+    return CacheResponse(site_hash=site_hash, actions=req.actions)
+
+@app.delete("/cache/{site_hash}", response_model=CacheResponse)
+async def cache_delete(site_hash: str) -> CacheResponse:
+    deleted = await _delete_cache(site_hash)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Cache miss")
+    return CacheResponse(site_hash=site_hash, actions=None)

--- a/mcp/gal-browser-use-service/requirements.txt
+++ b/mcp/gal-browser-use-service/requirements.txt
@@ -1,0 +1,7 @@
+browser-use>=0.1.0
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+playwright>=1.49.0
+pydantic>=2.10.0
+aiofiles>=24.0.0
+aiosqlite>=0.20.0

--- a/mcp/gal-browser-use-service/start.sh
+++ b/mcp/gal-browser-use-service/start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Start the GAL Browser Use Service
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ ! -d .venv ]]; then
+  python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+export PYTHONPATH="${PYTHONPATH:-}:$(pwd)"
+export GAL_BROWSER_USE_DB="${GAL_BROWSER_USE_DB:-/tmp/gal-browser-use-cache.db}"
+export GAL_BROWSER_USE_LLM="${GAL_BROWSER_USE_LLM:-gpt-4o}"
+export GAL_BROWSER_USE_MAX_STEPS="${GAL_BROWSER_USE_MAX_STEPS:-50}"
+
+exec uvicorn main:app --host 127.0.0.1 --port 8123 --reload


### PR DESCRIPTION
## What
Ports the missing browser-use build-out into `gal/mcp/chrome` (12 files, +1284):
- `src/server.ts` +600 — 10 new `gal-browser-use_*` tools (tabGroups create/list, tabs query/create/remove, bookmarks_search, history_search, windows_create, agent_run, enhanced_parse), added alongside the existing chrome_extension_*/gal_session tools (none removed).
- `test/unified-system.test.ts` + vitest config — integration test that **self-skips** when the Python service isn't running (no CI breakage).
- `mcp/gal-browser-use-service/` — the previously **untracked** Python service (main.py, chrome_bridge.py, Dockerfile, etc.) now committed.

## Why
Verifier-confirmed: the build-out + test were absent from `gal/mcp/chrome` (only the pre-PR base existed) and the Python service was an untracked loose dir.

## Verification
`tsc --noEmit` → **exit 0**. Secret scan clean. Integration test self-skips without the service.

Addresses #453. Surfaced by the archived-repo disposition audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
