### PR TITLE
chore(schemas): canonical schemas.gal.run $id for console config schemas [ci]

### DIFF
--- a/apps/console/schemas/project-config.schema.json
+++ b/apps/console/schemas/project-config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/Scheduler-Systems/gal-run/schemas/project-config.schema.json",
+  "$id": "https://schemas.gal.run/gal/v1/project-config.schema.json",
   "title": "GAL Project Config",
   "type": "object",
   "additionalProperties": false,

--- a/apps/console/schemas/workspace-config.schema.json
+++ b/apps/console/schemas/workspace-config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/Scheduler-Systems/gal-run/schemas/workspace-config.schema.json",
+  "$id": "https://schemas.gal.run/gal/v1/workspace-config.schema.json",
   "title": "GAL Workspace Config",
   "type": "object",
   "additionalProperties": false,


### PR DESCRIPTION
Two schemas already on `main` carry a **private-org `\$id`** on this PUBLIC repo:
- `apps/console/schemas/workspace-config.schema.json`
- `apps/console/schemas/project-config.schema.json`

both had `"\$id": "https://github.com/Scheduler-Systems/gal-run/schemas/..."` — a private org/repo URL (privacy nit + dead link). This switches them to the canonical public convention **`https://schemas.gal.run/gal/v1/...`**, matching the `decision-request`/`decision-result` and `capability-manifest` (#416) schemas.

`\$id`-only change; verified **nothing `\$ref`s these URLs**, so no consumers break. Both files remain valid JSON / JSON-Schema draft 2020-12.

Addresses #453.