### PR TITLE
chore(dependabot): drop the bun-managed web workspace from npm updates [ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,12 +30,14 @@ updates:
         applies-to: version-updates
         patterns: ["*"]
 
-  # npm — the app dirs that currently carry open security alerts
+  # npm — the app dirs that currently carry open security alerts.
+  # NOTE: packages/gal-code/packages/web is BUN-managed (bun.lock), not npm —
+  # an npm bump there can't update bun.lock and breaks `bun install
+  # --frozen-lockfile` in the gal-code CI job, so it is intentionally excluded.
   - package-ecosystem: npm
     directories:
       - "/"
       - "/apps/website"
-      - "/packages/gal-code/packages/web"
       - "/tools/demo-studio"
     schedule:
       interval: weekly


### PR DESCRIPTION
The npm Dependabot config listed `/packages/gal-code/packages/web` — but that workspace is **bun-managed** (`bun.lock`), not npm. An npm bump there cannot update the bun lockfile, so `bun install --frozen-lockfile` in the `gal-code` CI job rejects it (observed in **#477**, which kept regenerating a broken PR).

This removes that one directory from the npm `directories`. The other dirs (`/`, `/apps/website`, `/tools/demo-studio`) are unaffected. If the web workspace deps should be auto-updated, that needs a bun-aware setup, not the npm ecosystem.

Addresses #453.