### PR TITLE
feat: development flag — gate WIP features (M1: mcp-gateway stub tools) [ci]

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,45 @@
+# Feature tiers & the `development` flag
+
+gal organizes user-facing features into three tiers and gates not-yet-working
+features behind a **`development` flag**, so the shipped surface only advertises
+what actually works. This file is the source of truth for what is stable vs.
+in-development — docs/UI claims should derive from it, and CI should fail if a
+`development` feature is advertised as live.
+
+## Tiers
+
+| Tier | What | How it's gated |
+|------|------|----------------|
+| **convenience** | Works today: `gal hooks install` (git SDLC hooks), bundled MCP servers (`gal mcp terminal\|vision\|browser`), config discover/standardize/sync. | Shipped (stable). |
+| **enforcement** | Policy enforcement — the C reference-monitor kernel and the PreToolUse blocking gate. Built and unit-tested but **not yet wired to a runnable command**. | `development` flag (off by default). |
+| **enterprise** | EE / hosted-cloud features (`//go:build cloud` services, `ee/` packages). | Compile-time (`//go:build cloud`) + license. |
+
+## The `development` flag
+
+A feature whose status is **development** is **not advertised and not callable**
+unless `GAL_DEVELOPMENT=1` (or `true`). This keeps the shipped surface honest:
+nothing claims to work that doesn't.
+
+- **Default (unset):** development features are hidden and rejected as if they do not exist.
+- **`GAL_DEVELOPMENT=1`:** development features are surfaced — for contributors and testing.
+
+First gate landed: `services/mcp-gateway` — its 10 MCP tools are stub implementations
+(`// --- Tool implementations (stubs) ---`) returning hardcoded success. They are now
+tagged `development` and hidden from `tools/list` + rejected by `tools/call` unless the
+flag is set (see `mcp_development_test.go`).
+
+## Current status (2026-06-22)
+
+| Feature | Tier | Status |
+|---------|------|--------|
+| `gal hooks install` (git SDLC hooks) | convenience | stable |
+| MCP servers (`gal mcp terminal\|vision\|browser`) | convenience | stable |
+| config discover / standardize / sync | convenience | stable (hosted: needs an account) |
+| mcp-gateway MCP tools (compliance, config, discovery, governance, memory, org, policy, session, swarm, team) | enforcement | **development** (stub implementations — gated) |
+| per-tool blocking / PreToolUse gate / kernel runtime wiring | enforcement | **development** (built, not exposed by a command) |
+| cloud control-plane services | enterprise | `//go:build cloud` |
+
+> Roadmap: gate the remaining `development` surfaces (CLI `update`/`vscode`/`chrome`
+> stubs, computer-use-mcp), derive docs/UI claims from this table, and add a CI guard
+> that fails if a `development` feature is reachable un-flagged. See the v1.0
+> stabilization goal.

--- a/services/mcp-gateway/internal/handler/mcp.go
+++ b/services/mcp-gateway/internal/handler/mcp.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -22,6 +23,31 @@ const (
 	mcpServerName    = "gal-mcp-gateway"
 	mcpServerVersion = "0.1.0"
 )
+
+// developmentEnabled reports whether development-tier (work-in-progress) features
+// are exposed. Off by default: the gateway must not advertise or run features that
+// aren't real yet. Set GAL_DEVELOPMENT=1 (or true) to surface them.
+func developmentEnabled() bool {
+	v := os.Getenv("GAL_DEVELOPMENT")
+	return v == "1" || v == "true"
+}
+
+// developmentTools are advertised and callable ONLY when developmentEnabled().
+// Their implementations are stubs (see "Tool implementations (stubs)" below) that
+// return hardcoded success, so by default they are hidden from tools/list and
+// rejected by tools/call as if they did not exist.
+var developmentTools = map[string]bool{
+	"compliance": true,
+	"config":     true,
+	"discovery":  true,
+	"governance": true,
+	"memory":     true,
+	"org":        true,
+	"policy":     true,
+	"session":    true,
+	"swarm":      true,
+	"team":       true,
+}
 
 // mcpToolDefinitions are the GAL MCP tools exposed via Streamable HTTP.
 var mcpToolDefinitions = []domain.MCPToolDefinition{
@@ -279,8 +305,8 @@ func (g *GatewayService) handleMcpGet(w http.ResponseWriter, claims *domain.Toke
 // handleMcpDelete acknowledges session termination.
 func (g *GatewayService) handleMcpDelete(w http.ResponseWriter, claims *domain.TokenClaims) {
 	handler.RespondJSON(w, http.StatusOK, map[string]string{
-		"status":  "session_terminated",
-		"user":    claims.UserID,
+		"status": "session_terminated",
+		"user":   claims.UserID,
 	})
 }
 
@@ -311,8 +337,14 @@ func (g *GatewayService) processMCPRequest(ctx context.Context, req *domain.MCPR
 // --- tool/list handler ---
 
 func (g *GatewayService) handleToolsList(req *domain.MCPRequest) domain.MCPResponse {
-	tools := make([]domain.MCPToolDefinition, len(mcpToolDefinitions))
-	copy(tools, mcpToolDefinitions)
+	dev := developmentEnabled()
+	tools := make([]domain.MCPToolDefinition, 0, len(mcpToolDefinitions))
+	for _, t := range mcpToolDefinitions {
+		if developmentTools[t.Name] && !dev {
+			continue // hide work-in-progress tools unless GAL_DEVELOPMENT is set
+		}
+		tools = append(tools, t)
+	}
 	return domain.MCPResponse{
 		JSONRPC: "2.0",
 		ID:      req.ID,
@@ -461,6 +493,11 @@ func (g *GatewayService) handlePromptsGet(req *domain.MCPRequest) domain.MCPResp
 // --- Tool dispatch ---
 
 func (g *GatewayService) executeTool(name string, args map[string]any, claims *domain.TokenClaims) ([]map[string]any, map[string]any) {
+	// Development-tier tools are unavailable unless GAL_DEVELOPMENT is set; treat them
+	// as non-existent so tools/call returns "Unknown tool" rather than fake success.
+	if developmentTools[name] && !developmentEnabled() {
+		return nil, nil
+	}
 	switch name {
 	case "compliance":
 		return g.toolCompliance(args, claims)

--- a/services/mcp-gateway/internal/handler/mcp_development_test.go
+++ b/services/mcp-gateway/internal/handler/mcp_development_test.go
@@ -1,0 +1,54 @@
+//go:build cloud
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/gal-run/gal/services/mcp-gateway/internal/domain"
+)
+
+// TestDevelopmentToolsHiddenByDefault asserts the development gate: with
+// GAL_DEVELOPMENT unset, the stub tools are neither advertised by tools/list
+// nor callable via tools/call (they return as if they do not exist). This is
+// the honest default — the gateway must not advertise features that aren't real.
+func TestDevelopmentToolsHiddenByDefault(t *testing.T) {
+	t.Setenv("GAL_DEVELOPMENT", "")
+	g := &GatewayService{}
+
+	resp := g.handleToolsList(&domain.MCPRequest{ID: 1})
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("tools/list result is not a map: %#v", resp.Result)
+	}
+	tools, ok := result["tools"].([]domain.MCPToolDefinition)
+	if !ok {
+		t.Fatalf("tools field is not []MCPToolDefinition: %#v", result["tools"])
+	}
+	if len(tools) != 0 {
+		t.Fatalf("expected 0 tools advertised by default (all 10 are development stubs), got %d", len(tools))
+	}
+
+	content, _ := g.executeTool("compliance", map[string]any{"action": "check"}, &domain.TokenClaims{OrgID: "org-1"})
+	if content != nil {
+		t.Fatalf("development tool 'compliance' should be uncallable when GAL_DEVELOPMENT is unset")
+	}
+}
+
+// TestDevelopmentToolsVisibleWhenEnabled asserts the gate opens with the flag:
+// GAL_DEVELOPMENT=1 surfaces and runs the development-tier tools.
+func TestDevelopmentToolsVisibleWhenEnabled(t *testing.T) {
+	t.Setenv("GAL_DEVELOPMENT", "1")
+	g := &GatewayService{}
+
+	resp := g.handleToolsList(&domain.MCPRequest{ID: 1})
+	tools := resp.Result.(map[string]any)["tools"].([]domain.MCPToolDefinition)
+	if len(tools) != len(mcpToolDefinitions) {
+		t.Fatalf("expected all %d tools advertised with GAL_DEVELOPMENT=1, got %d", len(mcpToolDefinitions), len(tools))
+	}
+
+	content, _ := g.executeTool("compliance", map[string]any{"action": "check"}, &domain.TokenClaims{OrgID: "org-1"})
+	if content == nil {
+		t.Fatalf("development tool 'compliance' should be callable with GAL_DEVELOPMENT=1")
+	}
+}


### PR DESCRIPTION
## M1 — the `development` flag (stabilize by scoping, not grinding)

Addresses #485 — instead of hand-fixing every not-working surface to green, **gate what isn't working behind a `development` flag** so the shipped surface only advertises what actually works. This is the structural enforcement of "lead with what ships, remove unsubstantiated claims": claims derive from the flag, so a feature can't be advertised as live until it really is.

### Mechanism
- `GAL_DEVELOPMENT` env var (default off = stable). Off → `development`-tier features are **not advertised and not callable**.
- Applied at the exposure point (the registry), not scattered.

### First gate: mcp-gateway's 10 stub tools
`services/mcp-gateway`'s MCP tools (`compliance`, `config`, `discovery`, `governance`, `memory`, `org`, `policy`, `session`, `swarm`, `team`) are **stub implementations** (`// --- Tool implementations (stubs) ---`) returning hardcoded success ("always compliant", "always synced", "always approved"). This PR tags them `development`:
- `handleToolsList` filters them out by default.
- `executeTool` returns nil for them → `tools/call` responds "Unknown tool".
- With `GAL_DEVELOPMENT=1` they're surfaced (contributors/testing).
- `mcp_development_test.go` asserts both states (0 by default + uncallable; all 10 + callable when enabled).

### `FEATURES.md`
A source-of-truth manifest of the three tiers + per-feature status. Docs/UI claims should derive from it; a CI guard (follow-up) fails if a `development` feature is advertised as live.

### Verification
`services/mcp-gateway` is `//go:build cloud` (can't build locally — private firestore overlay), so verified by **inspection + `gofmt`**; **gal-cloud CI runs the test**.

### Gate
- Merge to `main` = founder sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
