### PR TITLE
feat: development flag — gate WIP CLI commands (M2: update/vscode/chrome-extension) [ci]

### DIFF
--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -63,12 +63,9 @@ gal auth login
 gal sync --pull
 ```
 
-Update:
+Update with your package manager:
 
 ```bash
-gal update
-
-# or with your package manager
 brew upgrade gal
 npm install -g @gal-run/cli@latest
 pnpm add -g @gal-run/cli@latest

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,6 +137,7 @@ enum Commands {
     /// Uninstall GAL CLI
     Uninstall(uninstall::UninstallArgs),
     /// Update GAL CLI
+    #[command(hide = true)] // in-development: gated behind GAL_DEVELOPMENT (see FEATURES.md)
     Update(update::UpdateArgs),
     /// Work item management
     Work(work::WorkArgs),
@@ -147,8 +148,10 @@ enum Commands {
     /// Vision MCP server
     Vision(vision::VisionArgs),
     /// VS Code MCP server
+    #[command(hide = true)] // in-development: gated behind GAL_DEVELOPMENT (see FEATURES.md)
     Vscode(vscode::VscodeArgs),
     /// Chrome Extension MCP server
+    #[command(hide = true)] // in-development: gated behind GAL_DEVELOPMENT (see FEATURES.md)
     ChromeExtension(chrome_extension::ChromeExtensionArgs),
     /// MCP (Model Context Protocol) servers for AI coding agents
     Mcp(McpArgs),
@@ -168,6 +171,24 @@ pub enum McpServer {
     Vision,
     /// Browser MCP server - Headless Chrome browser automation
     Browser,
+}
+
+/// The `development` gate: an in-development feature is only enabled when
+/// `GAL_DEVELOPMENT` is `1` or `true`. Mirrors the mcp-gateway gate so the whole
+/// repo shares one convention — the shipped surface advertises only what works.
+fn development_enabled() -> bool {
+    matches!(
+        std::env::var("GAL_DEVELOPMENT").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Error for an in-development command invoked without `GAL_DEVELOPMENT`.
+fn development_disabled(cmd: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "`gal {cmd}` is an in-development command and isn't available in this build. \
+         Set GAL_DEVELOPMENT=1 to enable it (for contributors/testing). See FEATURES.md."
+    )
 }
 
 #[tokio::main]
@@ -246,13 +267,21 @@ async fn main() -> anyhow::Result<()> {
         Commands::Test(args) => test_cmd::run(client, args).await,
         Commands::Trigger(args) => trigger::run(client, args).await,
         Commands::Uninstall(args) => uninstall::run(client, args).await,
-        Commands::Update(args) => update::run(client, args).await,
+        // In-development commands: gated behind GAL_DEVELOPMENT so the shipped
+        // surface only advertises what works (see FEATURES.md). They are also
+        // hidden from `--help`; without the flag they are rejected as unavailable.
+        Commands::Update(args) if development_enabled() => update::run(client, args).await,
+        Commands::Update(_) => Err(development_disabled("update")),
+        Commands::Vscode(args) if development_enabled() => vscode::run(client, args).await,
+        Commands::Vscode(_) => Err(development_disabled("vscode")),
+        Commands::ChromeExtension(args) if development_enabled() => {
+            chrome_extension::run(client, args).await
+        }
+        Commands::ChromeExtension(_) => Err(development_disabled("chrome-extension")),
         Commands::Work(args) => work::run(client, args).await,
         Commands::Workspace(args) => workspace::run(client, args).await,
         Commands::Terminal(args) => terminal::run(client, args).await,
         Commands::Vision(args) => vision::run(client, args).await,
-        Commands::Vscode(args) => vscode::run(client, args).await,
-        Commands::ChromeExtension(args) => chrome_extension::run(client, args).await,
         Commands::Mcp(_) => unreachable!(), // handled above
     }
 }

--- a/cli/tests/development_gate.rs
+++ b/cli/tests/development_gate.rs
@@ -1,0 +1,98 @@
+//! Regression test for the `development` gate (see FEATURES.md).
+//!
+//! In-development CLI commands (`update`, `vscode`, `chrome-extension`) are
+//! stubs — `update` fakes an update check, `vscode`/`chrome-extension` fall
+//! back to a terminal MCP server while claiming to be IDE/browser integrations.
+//! Until they really work they must be **neither advertised nor callable**
+//! unless `GAL_DEVELOPMENT=1`, so the shipped surface stays honest.
+//!
+//! These cases invoke the built `gal` binary. The ungated commands error
+//! immediately at dispatch (they never start the blocking stdio server), so the
+//! test stays fast; we deliberately do NOT run `vscode`/`chrome-extension`
+//! *with* the flag, since those would start a server and block.
+
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_gal");
+
+/// Without the flag, an in-development command is rejected as unavailable.
+#[test]
+fn update_rejected_when_flag_unset() {
+    let out = Command::new(BIN)
+        .args(["update", "update"])
+        .env_remove("GAL_DEVELOPMENT")
+        .output()
+        .expect("run gal");
+    assert!(
+        !out.status.success(),
+        "`gal update` must fail without GAL_DEVELOPMENT; exit was success"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("in-development"),
+        "expected an in-development gate message, got: {stderr}"
+    );
+}
+
+/// With GAL_DEVELOPMENT=1 the gate opens and the command runs (the `update`
+/// stub prints and returns Ok, so it exits cleanly).
+#[test]
+fn update_runs_when_flag_set() {
+    let out = Command::new(BIN)
+        .args(["update", "update"])
+        .env("GAL_DEVELOPMENT", "1")
+        .output()
+        .expect("run gal");
+    assert!(
+        out.status.success(),
+        "`gal update` must run with GAL_DEVELOPMENT=1; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// `vscode` and `chrome-extension` are gated the same way.
+#[test]
+fn ide_integrations_rejected_when_flag_unset() {
+    for cmd in [
+        vec!["vscode", "start"],
+        vec!["chrome-extension", "mcp-server"],
+    ] {
+        let out = Command::new(BIN)
+            .args(&cmd)
+            .env_remove("GAL_DEVELOPMENT")
+            .output()
+            .expect("run gal");
+        assert!(
+            !out.status.success(),
+            "`gal {}` must fail without GAL_DEVELOPMENT",
+            cmd.join(" ")
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("in-development"),
+            "expected gate message for `gal {}`, got: {stderr}",
+            cmd.join(" ")
+        );
+    }
+}
+
+/// The in-development commands must not be advertised in top-level `--help`.
+#[test]
+fn development_commands_hidden_from_help() {
+    let out = Command::new(BIN)
+        .arg("--help")
+        .env_remove("GAL_DEVELOPMENT")
+        .output()
+        .expect("run gal --help");
+    let help = String::from_utf8_lossy(&out.stdout);
+    for doc in [
+        "Update GAL CLI",
+        "VS Code MCP server",
+        "Chrome Extension MCP server",
+    ] {
+        assert!(
+            !help.contains(doc),
+            "in-development command `{doc}` must be hidden from --help"
+        );
+    }
+}


### PR DESCRIPTION
## M2 — extend the `development` flag to the Rust CLI

Addresses #485. Second increment of the v1.0 stabilization goal: after the mechanism + first gate landed for the Go mcp-gateway (#488), this gates the **three stub CLI commands** so `gal`'s shipped surface only advertises what actually works.

### The stubs (verified against real code, not comments)
| Command | What it actually does today |
|---|---|
| `gal update` | Fakes a check (`tokio::time::sleep`) then prints "GAL vX is the latest version" **without checking anything**, and tells you to update via cargo/brew. No self-update. |
| `gal vscode start \| mcp-server` | Prints "Starting VS Code MCP server…" then **falls back to a terminal MCP server** (`// in a real impl would connect to VS Code extension`). |
| `gal chrome-extension mcp-server` | Same pattern — claims a chrome-extension server, starts a terminal MCP server instead. |

(The real VS Code extension and Chrome extension apps are functional and untouched — only these misleading **CLI wrappers** are gated.)

### The gate (same convention as #488)
- `#[command(hide = true)]` → removed from `gal --help`.
- Dispatch guard: `development_enabled()` = `GAL_DEVELOPMENT` ∈ {`1`,`true`} (identical to the Go `developmentEnabled()`). Without it → honest error; with it → runs (contributors/testing).

### Measured proof (`cli/tests/development_gate.rs`, no new deps)
- ✅ `update`/`vscode`/`chrome-extension` **absent from `gal --help`**
- ✅ each **rejected** (`exit 1`, "in-development" message) when `GAL_DEVELOPMENT` unset
- ✅ `gal update update` **runs** (`exit 0`) with `GAL_DEVELOPMENT=1`

Eyes-on verified the same. Build: `cargo test` green (28 warnings all pre-existing); **OSS build `--no-default-features` green**; change is surgical (only `main.rs` + new test — no whole-crate reformat).

### Note on `FEATURES.md`
Intentionally **not** touched here: `FEATURES.md` is introduced by #488 (not yet on `main`), and its "Roadmap" line already names exactly this work ("gate the remaining development surfaces — CLI update/vscode/chrome stubs"). Editing it in both branches would create an add/add conflict. Its status table flips these rows to *development (gated)* in a follow-up once #488 lands.

### Gate
- Merge to `main` = founder sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
