### PR TITLE
fix: scrub hardcoded local developer paths from public tree (T6) [ci]

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -266,7 +266,7 @@ export interface Organization {
   name: string
   installationId: number
   accountType?: 'User' | 'Organization' | 'Enterprise' // GitHub account type (personal, org, or enterprise)
-  enterpriseSlug?: string // Enterprise account this org belongs to (e.g. "scheduler-systems-ltd")
+  enterpriseSlug?: string // Enterprise account this org belongs to (e.g. "acme-corp")
   canDelete?: boolean
   installedByGithubId?: number
   installedByLogin?: string

--- a/packages/gal-code/packages/gal-code/src/bootstrap/builtin-mcp.ts
+++ b/packages/gal-code/packages/gal-code/src/bootstrap/builtin-mcp.ts
@@ -1,5 +1,4 @@
 import path from "path"
-import { homedir } from "os"
 import { existsSync } from "fs"
 
 type McpEntry = {
@@ -41,14 +40,14 @@ function resolveStandaloneMcp(localPath: string, pkg: string, altPath?: string):
 export function buildBuiltinMcp(env: NodeJS.ProcessEnv = process.env, cwd = process.cwd()): McpConfig {
   const hasVision = env.GEMINI_API_KEY || env.GOOGLE_CLOUD_PROJECT || env.GCP_PROJECT
   const hasVoice = env.OPENAI_API_KEY
-  const stratus =
-    env.STRATUS_MCP_PATH || path.join(homedir(), "Documents/scheduler-systems/stratus/stratus-shell/mcp/dist/index.js")
+  // Optional internal Stratus MCP — set STRATUS_MCP_PATH to its dist entry to enable it.
+  const stratus = env.STRATUS_MCP_PATH
   const gal = resolveGalCli(env)
   const cmd = gal ?? ["gal"]
   const root =
     env.GAL_CODE_WORKSPACE_ROOT ||
     env.GAL_DEV_WORKSPACE_ROOT ||
-    path.join(homedir(), "Documents/scheduler-systems-ltd/gal-run")
+    cwd
   // Normalize: if root is a sub-repo (e.g. gal-cli), go up to monorepo root
   const monoRoot = existsSync(path.join(root, "packages", "gal-code")) ? root : path.resolve(root, "..")
   const terminalUseMcp = resolveStandaloneMcp(

--- a/packages/gal-code/packages/gal-code/src/cli/cmd/tui/feature-plugins/prompt/voice.tsx
+++ b/packages/gal-code/packages/gal-code/src/cli/cmd/tui/feature-plugins/prompt/voice.tsx
@@ -8,9 +8,9 @@ const id = "internal:prompt-voice"
 const STATE_FILE = "/tmp/gal-voice-state"
 const LEVEL_FILE = "/tmp/gal-voice-level"
 const INPUT_FILE = "/tmp/gal-voice.txt"
-const DAEMON_SCRIPT =
-  process.env.GAL_VOICE_DAEMON ||
-  "/Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run/gal-android/scripts/gal-voice-daemon"
+// Set GAL_VOICE_DAEMON to the absolute path of the gal-voice daemon; the
+// bare default resolves via PATH (the daemon ships separately).
+const DAEMON_SCRIPT = process.env.GAL_VOICE_DAEMON || "gal-voice-daemon"
 
 const exitRegex = /^(?:exit|stop|end)\s*voice$/i
 

--- a/packages/gal-code/packages/gal-code/test/config/mcp-config-merge.test.ts
+++ b/packages/gal-code/packages/gal-code/test/config/mcp-config-merge.test.ts
@@ -6,7 +6,7 @@ const ROOT =
   process.env.GAL_CODE_WORKSPACE_ROOT ||
   process.env.GAL_DEV_WORKSPACE_ROOT ||
   process.env.GITHUB_WORKSPACE ||
-  "/Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run"
+  process.cwd()
 
 describe("MCP config — no broken 'gal' command references", () => {
   test(".mcp.json does not use 'gal' as command", () => {

--- a/packages/gal-code/packages/gal-code/test/voice/voice-orb-render.test.ts
+++ b/packages/gal-code/packages/gal-code/test/voice/voice-orb-render.test.ts
@@ -6,9 +6,7 @@ import os from "os"
 
 const STATE_FILE = path.join(os.tmpdir(), "gal-voice-state")
 const LEVEL_FILE = path.join(os.tmpdir(), "gal-voice-level")
-const BINARY =
-  process.env.GAL_CODE_BINARY ||
-  "/Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run/gal-code/packages/gal-code/dist/gal-code-darwin-arm64/bin/gal-code"
+const BINARY = process.env.GAL_CODE_BINARY || "gal-code"
 const hasBinary = existsSync(BINARY)
 const desc = hasBinary ? describe : (describe.skip as (name: string, fn: () => void) => void)
 

--- a/packages/gal-code/packages/gal-code/test/voice/voice-pipeline.test.ts
+++ b/packages/gal-code/packages/gal-code/test/voice/voice-pipeline.test.ts
@@ -9,9 +9,7 @@ const LEVEL_FILE = path.join(os.tmpdir(), "gal-voice-level")
 const INPUT_FILE = path.join(os.tmpdir(), "gal-voice.txt")
 const MSGID_FILE = path.join(os.tmpdir(), "gal-voice-msgid")
 const PID_FILE = path.join(os.tmpdir(), "gal-voice-daemon.pid")
-const DAEMON_SCRIPT =
-  process.env.GAL_VOICE_DAEMON ||
-  "/Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run/gal-android/scripts/gal-voice-daemon"
+const DAEMON_SCRIPT = process.env.GAL_VOICE_DAEMON || "gal-voice-daemon"
 const hasDaemon = existsSync(DAEMON_SCRIPT)
 const desc = hasDaemon ? describe : (describe.skip as (name: string, fn: () => void) => void)
 

--- a/packages/gal-code/packages/gal-code/test/voice/voice-slash-dispatch.test.ts
+++ b/packages/gal-code/packages/gal-code/test/voice/voice-slash-dispatch.test.ts
@@ -6,9 +6,7 @@ import os from "os"
 
 const STATE_FILE = path.join(os.tmpdir(), "gal-voice-state")
 const PID_FILE = path.join(os.tmpdir(), "gal-voice-daemon.pid")
-const DAEMON_SCRIPT =
-  process.env.GAL_VOICE_DAEMON ||
-  "/Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run/gal-android/scripts/gal-voice-daemon"
+const DAEMON_SCRIPT = process.env.GAL_VOICE_DAEMON || "gal-voice-daemon"
 const hasDaemon = existsSync(DAEMON_SCRIPT)
 const desc = hasDaemon ? describe : (describe.skip as (name: string, fn: () => void) => void)
 

--- a/services/gal-rag/TECH.md
+++ b/services/gal-rag/TECH.md
@@ -760,7 +760,7 @@ chain that the gateway already supports.
 ### 10.2 First-run
 
 ```bash
-cd /Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run/backend/gal-rag
+cd path/to/gal-run/backend/gal-rag
 
 # 1. Start Qdrant
 cd dev && docker compose up -d && cd ..

--- a/services/gal-rag/dev/README.md
+++ b/services/gal-rag/dev/README.md
@@ -7,7 +7,7 @@ Local Qdrant instance for developing and testing the gal-rag retrieval service.
 ## Quick Start
 
 ```bash
-cd /Users/scheduler-systems/Documents/scheduler-systems-ltd/gal-run/backend/gal-rag/dev
+cd path/to/gal-run/backend/gal-rag/dev
 
 # Start Qdrant
 docker compose up -d


### PR DESCRIPTION
## Scrub hardcoded local developer paths from the public tree (M4 · T6)

Addresses #485. Part of the v1.0 stabilization goal's **T6 ("no leaks")** eval. Several files in the public repo hardcoded **one developer's absolute/home filesystem paths** as fallbacks — leaking a local machine's directory layout + internal repo names, and only ever resolving on that one machine.

### What was leaking (now `git grep`-clean: 0 remaining)
| File | Was | Now |
|---|---|---|
| `voice.tsx`, `voice-pipeline`, `voice-slash-dispatch` | `GAL_VOICE_DAEMON \|\| "/Users/…/gal-android/scripts/gal-voice-daemon"` | `\|\| "gal-voice-daemon"` (PATH) |
| `voice-orb-render.test` | `GAL_CODE_BINARY \|\| "/Users/…/dist/…/bin/gal-code"` | `\|\| "gal-code"` |
| `mcp-config-merge.test` | workspace-root `\|\| "/Users/…/gal-run"` | `\|\| process.cwd()` |
| `builtin-mcp.ts` | `STRATUS_MCP_PATH \|\| homedir()+"Documents/scheduler-systems/stratus/…"`; root `\|\| homedir()+"Documents/scheduler-systems-ltd/gal-run"` | `STRATUS_MCP_PATH` required (gated by `existsSync`); root `\|\| cwd`; dropped unused `homedir` import |
| `dashboard/api.ts` | comment `e.g. "scheduler-systems-ltd"` | `e.g. "acme-corp"` |
| `gal-rag` `TECH.md`, `dev/README.md` | `cd /Users/…/gal-run/backend/gal-rag` | `cd path/to/gal-run/backend/gal-rag` |

### Why it's safe (behavior-preserving)
Every leaky string was a **fallback after an env-var override**, and on CI/other machines it either (a) isn't used because the env var is set, or (b) points at a path that doesn't exist → the test already `skip`s / the feature is already not configured. So CI behavior is unchanged; only the original author's machine flips from "auto-resolves a private path" to "set the env var" — which is the correct, non-leaky behavior.

### Deliberately NOT touched
- **Public brand identity** — `scheduler-systems/tap/gal-code`, `gal-by-scheduler-systems` (GitHub App), `ghcr.io/scheduler-systems`, the VS Code publisher. These are how users install/identify the product; scrubbing them would break installs.
- **`@scheduler-systems/` npm scope** (1202 refs / 354 files) — a separate **G3** concern that needs a founder decision on the canonical published scope. Flagged, not changed.

### Verification
`git grep` → **0** remaining `/Users/…`, `homedir()+Documents`, or `scheduler-systems-ltd` filesystem refs. `gal-code` is not in CI, so its files are **inspection-verified** (type-safe: `stratus` is guarded by `&& existsSync`; `cwd` is the function param; `api.ts` is comment-only).

### Gate
- Merge to `main` = founder sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
