### PR TITLE
ci: run gal-code + app unit tests in CI (T5 part A) [ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
               - 'model/**'
             gal_code:
               - 'packages/gal-code/**'
+              - '.github/workflows/ci.yml'
 
   # Always-on, fast license-by-location fence.
   fence:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,5 +185,11 @@ jobs:
         run: bun install --frozen-lockfile
       - name: typecheck (turbo, all gal-code packages)
         run: bun run typecheck
+      - name: unit tests (gal-code + app, junit)
+        # --concurrency=1: run the two suites serially. Running them concurrently
+        # induces a CPU-contention timing flake in test/session/compaction.test.ts
+        # ("does not allow tool calls while generating the summary"); each suite is
+        # reliably green on its own (2214 + 308 pass). Tracked separately.
+        run: bun turbo test:ci --concurrency=1
       - name: astro build (web app)
         run: bun run --cwd packages/web build


### PR DESCRIPTION
## T5 (partial): run gal-code's ~2,261 tests + app tests in CI

Addresses #485. Closes the **T5 Part A** gap of the v1.0 stabilization goal: the `gal-code` CI job ran **typecheck + astro build only** — its test suites never executed in CI, even though CI-safe `test:ci` turbo tasks already existed (`@gal-run/code#test:ci`, `@scheduler-systems/gal-code-app#test:ci` — `bun test` + junit output).

### Change
- Add one step to the `gal-code` job: `bun turbo test:ci --concurrency=1`.
- Add `.github/workflows/ci.yml` to the `gal_code` paths-filter so the job re-runs when its own CI definition changes (lets this PR self-validate).

### Verified locally (`bun install --frozen-lockfile`, 4715 pkgs)
| Suite | Result |
|---|---|
| `@gal-run/code` | **2214 pass / 48 skip / 0 fail** (184 files) |
| `@scheduler-systems/gal-code-app` | **308 pass / 0 fail** (52 files) |

(The 48 skips are env-dependent voice/installation suites that self-`describe.skip` when their daemon/binary is absent — CI-safe.)

### Why `--concurrency=1`
Running both suites **concurrently** induces a CPU-contention timing flake in `test/session/compaction.test.ts:900` ("does not allow tool calls while generating the summary") — **0/20 fails in isolation**, 0-fail across repeated full-suite runs, but ~1/few fails only under concurrent turbo load. Diagnosis: a load-sensitive race, **not** a deterministic product bug (the test and `processor.ts` summary-guard are correct). Serial execution matches the reliably-green condition and gives honest coverage without the flake. `bun turbo test:ci --concurrency=1` verified green end-to-end (gal-code ~160s + app <1s). The underlying race is noted for separate, focused triage rather than masked.

### Scope note
This is **T5 Part A** (tests in CI). T5 Part B — *"a guard fails if a `development` feature is reachable un-flagged"* — needs `FEATURES.md` + the gates from #488/#489 on `main` first, and follows once those land.

### Gate
- Merge to `main` = founder sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
