### PR TITLE
ci: dev-gate guard — fail if a development feature is reachable un-flagged (T5 part B) [ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
         with: { node-version: "20" }
       - run: node tools/check-license-fence.mjs
 
+  # Always-on guard: fail if an in-development feature is reachable without the flag.
+  dev-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with: { node-version: "20" }
+      - run: node tools/check-development-gate.mjs
+
   kernel:
     needs: changes
     if: ${{ needs.changes.outputs.kernel == 'true' }}

--- a/tools/check-development-gate.mjs
+++ b/tools/check-development-gate.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// T5 guard: fail if an in-development feature is reachable without the flag.
+//
+// "claims derive from the flag" (FEATURES.md): every CLI command marked
+// `#[command(hide = true)] // in-development: gated behind GAL_DEVELOPMENT` MUST
+// also be (a) hidden from `--help` and (b) dispatch-guarded by `development_enabled()`
+// with a reject arm — so it is neither advertised nor callable by default. This
+// static check catches the regression where someone marks a command in-development
+// (or adds one) but forgets to gate its dispatch, leaving it reachable un-flagged.
+//
+// Self-skips when the development-gate mechanism isn't present in the tree yet
+// (e.g. before the CLI gate lands), so it is safe to ship ahead of the gate.
+
+import { readFileSync } from "node:fs";
+
+const MAIN = "cli/src/main.rs";
+const MARKER = "in-development: gated behind GAL_DEVELOPMENT";
+
+let src;
+try {
+  src = readFileSync(MAIN, "utf8");
+} catch {
+  console.log(`check-development-gate: skipped — ${MAIN} not found`);
+  process.exit(0);
+}
+
+if (!src.includes("fn development_enabled()")) {
+  console.log("check-development-gate: skipped — development gate mechanism not present yet");
+  process.exit(0);
+}
+
+const lines = src.split("\n");
+const devCommands = [];
+for (let i = 0; i < lines.length; i++) {
+  if (!lines[i].includes(MARKER)) continue;
+  const m = (lines[i + 1] || "").match(/^\s*([A-Z][A-Za-z0-9]*)\s*\(/);
+  if (m) devCommands.push(m[1]);
+}
+
+if (devCommands.length === 0) {
+  console.error(
+    "check-development-gate: FAIL — gate mechanism present but 0 commands carry the " +
+      `\`${MARKER}\` marker (was a gated command silently un-marked?)`,
+  );
+  process.exit(1);
+}
+
+const errors = [];
+for (const cmd of devCommands) {
+  const guarded = new RegExp(`Commands::${cmd}\\(args\\)\\s+if\\s+development_enabled\\(\\)`).test(src);
+  const rejected = new RegExp(`Commands::${cmd}\\(_\\)\\s*=>\\s*Err\\(development_disabled\\(`).test(src);
+  if (!guarded) errors.push(`${cmd}: REACHABLE UN-FLAGGED — missing \`if development_enabled()\` dispatch guard`);
+  if (!rejected) errors.push(`${cmd}: missing \`Commands::${cmd}(_) => Err(development_disabled(...))\` reject arm`);
+}
+
+if (errors.length) {
+  console.error("check-development-gate: FAIL — in-development feature(s) not gated:");
+  for (const e of errors) console.error("  - " + e);
+  process.exit(1);
+}
+
+console.log(`check-development-gate: OK — ${devCommands.length} in-development command(s) gated (${devCommands.join(", ")})`);


### PR DESCRIPTION
## T5 part B: CI guard — fail if a development feature is reachable un-flagged

Addresses #485. Completes **T5** ("a guard fails if a development feature is reachable un-flagged") alongside Part A (#491, gal-code/app tests in CI).

### What it does
- `tools/check-development-gate.mjs` — a fast static check (no build). For every CLI command marked `#[command(hide = true)] // in-development: gated behind GAL_DEVELOPMENT`, it asserts the dispatch has **both** `if development_enabled()` (gate) **and** the `development_disabled(...)` reject arm. If a marked command lacks the guard → it's reachable un-flagged → **the job fails**.
- An always-on `dev-gate` CI job (mirrors the existing `fence` job) runs it on every PR.

This makes the FEATURES.md principle — *"claims derive from the flag"* — enforced by CI, and catches the regression where someone adds/marks an in-development command but forgets to gate it.

### Measured verification (re-runnable: `node tools/check-development-gate.mjs`)
| Case | Setup | Expected | Result |
|---|---|---|---|
| **positive** | gated state (Update/Vscode/ChromeExtension) | exit 0 | ✅ `OK — 3 in-development command(s) gated` |
| **negative** | un-gate `Update` (drop its dispatch guard) | exit 1 | ✅ `FAIL — Update: REACHABLE UN-FLAGGED` |
| **self-skip** | tree without the gate mechanism | exit 0, skip | ✅ `skipped — development gate mechanism not present yet` |

### Safe to merge in any order
The guard **self-skips** until `fn development_enabled()` exists in the tree, so on current `main` (before the CLI gate #489 lands) the `dev-gate` job passes as a no-op, then **auto-activates** once #489 merges. No stacking required.

### Integrated proof
On a local integration of `main` + #488 + #489 + #490 + #491 + this guard, **all of T1–T6 pass**: T1 CLI 104/0, T2 gate 4/0 + guard OK, T3 console README 0 stale claims, T4 cloud files excluded from OSS build, T5 tests wired + guard green, T6 0 leaks.

### Gate
- Merge to `main` = founder sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
