### PR TITLE
fix(dashboard): stop 'Invalid Date Invalid Date' on Discovery (S6) [ci]

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/discovery/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/discovery/page.tsx
@@ -725,8 +725,12 @@ function Discovery() {
           )}
           {!scanning && (() => {
             const org = organizations.find(o => o.name === orgName)
-            if (!org?.lastScanAt) return null
+            // Guard the whole timestamp path: a never-scanned org (no lastScanAt),
+            // a malformed timestamp (no _seconds), or any value that yields an
+            // invalid Date must NOT render "Invalid Date Invalid Date".
+            if (!org?.lastScanAt?._seconds) return null
             const scanDate = new Date(org.lastScanAt._seconds * 1000)
+            if (isNaN(scanDate.getTime())) return null
             return (
               <span className="text-xs text-[var(--text-muted)]">
                 Last scanned: {scanDate.toLocaleDateString()} {scanDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}


### PR DESCRIPTION
## What
The Discovery page's 'Last scanned' line guarded only `!org?.lastScanAt` (object truthiness), so a never-scanned org or a malformed timestamp (no `_seconds`) produced `new Date(NaN)` -> **'Invalid Date Invalid Date'** (observed live on app.gal.run/discovery).

## Fix
Guard the full timestamp path: require `lastScanAt._seconds` and drop the line if the resulting Date is invalid (`isNaN`). Defensive only -- no type changes, no behavior change for a real timestamp.

## Verification
- `npx tsc --noEmit` -> 0 errors in discovery/page.tsx
- dashboard `vitest` -> 358/358 pass

Fixes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
