### PR TITLE
[ci] fix(website): blog post route 500s on Next 14 (use() on non-Promise params)

### DIFF
--- a/apps/website/app/blog/[slug]/page.tsx
+++ b/apps/website/app/blog/[slug]/page.tsx
@@ -14,9 +14,14 @@ import { DASHBOARD_URL } from "@/src/config";
 export default function ArticlePage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string }> | { slug: string };
 }) {
-  const { slug } = use(params);
+  // Cross-version params: Next 15 passes a Promise (resolve with use()); Next 14
+  // passes a plain object. React's use() is allowed to be called conditionally.
+  const { slug } =
+    typeof (params as { then?: unknown }).then === "function"
+      ? use(params as Promise<{ slug: string }>)
+      : (params as { slug: string });
   const article = getArticleBySlug(slug);
   const [currentSection, setCurrentSection] = useState("");
 


### PR DESCRIPTION
## What

Fixes a production 500 on **every** blog post detail page (`/blog/[slug]`) on gal.run.

`apps/website/app/blog/[slug]/page.tsx` called `use(params)` assuming Next-15 Promise
params, but `next` is pinned `^14.2.0`, where `params` is a plain object — so React threw
*"An unsupported type was passed to use()"* and every blog post returned HTTP 500. The blog
index (`/blog`) was unaffected, which is why this went unnoticed.

The change makes param resolution cross-version: resolve with `use()` only when `params` is
thenable (Next 15), otherwise use it directly (Next 14).

## Why this is priority

Live production outage: as of 2026-06-23, every existing blog post on gal.run returns 500.
This restores all of them. **Ship first**, independent of any content change.

## Verification

- `tsc --noEmit`: clean.
- The identical change was served off a production build and confirmed `/blog/introducing-gal`
  and other existing slugs return **200** instead of 500.

## Scope

One file — `apps/website/app/blog/[slug]/page.tsx`, +7/−2. No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #497
