### PR TITLE
gal-browser: fix CDP eval bug + add console/network/a11y observation primitives

### DIFF
--- a/cli/src/mcp/browser.rs
+++ b/cli/src/mcp/browser.rs
@@ -337,7 +337,7 @@ impl BrowserMcpServer {
                             selector, text
                         );
 
-                        match instance.page.evaluate_function(&js).await {
+                        match instance.page.evaluate(js.as_str()).await {
                             Ok(_) => ToolResult::json(&serde_json::json!({
                                 "success": true,
                                 "selector": selector,
@@ -375,7 +375,7 @@ impl BrowserMcpServer {
             selector
         );
 
-        match instance.page.evaluate_function(&js).await {
+        match instance.page.evaluate(js.as_str()).await {
             Ok(result) => {
                 // The result should be a string
                 let text = result
@@ -406,8 +406,10 @@ impl BrowserMcpServer {
             })()
         "#;
 
-        // Chromiumoxide evaluate_function returns a Value, we need to parse it
-        match instance.page.evaluate_function(js).await {
+        // Use Runtime.evaluate (page.evaluate) — the JS is an expression/IIFE,
+        // not a bare function declaration, so evaluate_function rejects it with
+        // "Given expression does not evaluate to a function".
+        match instance.page.evaluate(js).await {
             Ok(result) => {
                 let text = result
                     .value()
@@ -433,7 +435,7 @@ impl BrowserMcpServer {
 
         let instance = guard.as_ref().unwrap();
 
-        match instance.page.evaluate_function(&script).await {
+        match instance.page.evaluate(script.as_str()).await {
             Ok(result) => {
                 let value = result
                     .value()

--- a/cli/src/mcp/browser.rs
+++ b/cli/src/mcp/browser.rs
@@ -17,6 +17,8 @@
 use crate::mcp::{
     param_bool_or, param_str, param_u64_or, ContentItem, McpServer, Tool, ToolResult,
 };
+use chromiumoxide::cdp::browser_protocol::network::{EnableParams as NetworkEnableParams, EventRequestWillBeSent};
+use chromiumoxide::cdp::js_protocol::runtime::EventConsoleApiCalled;
 use futures::StreamExt;
 use serde_json::Value;
 use std::sync::Arc;
@@ -31,6 +33,10 @@ struct BrowserInstance {
     #[allow(dead_code)]
     browser: chromiumoxide::Browser,
     page: chromiumoxide::Page,
+    /// Captured console messages (console.log/error/warn ...), newest last.
+    console: Arc<Mutex<Vec<String>>>,
+    /// Captured network requests ("METHOD url"), newest last.
+    network: Arc<Mutex<Vec<String>>>,
 }
 
 pub struct BrowserMcpServer {
@@ -107,6 +113,16 @@ fn tools_list() -> Vec<Tool> {
             inputSchema: serde_json::from_str(r#"{"type":"object","properties":{"script":{"type":"string","description":"JavaScript code to execute"}},"required":["script"]}"#).ok(),
         },
         Tool {
+            name: "browser_read_console".to_string(),
+            description: "Read console messages (log/error/warn) captured since launch. Optional 'pattern' substring filter.".to_string(),
+            inputSchema: serde_json::from_str(r#"{"type":"object","properties":{"pattern":{"type":"string","description":"Only return messages containing this substring"}},"required":[]}"#).ok(),
+        },
+        Tool {
+            name: "browser_read_network".to_string(),
+            description: "Read network requests (\"METHOD url\") captured since launch. Optional 'pattern' substring filter.".to_string(),
+            inputSchema: serde_json::from_str(r#"{"type":"object","properties":{"pattern":{"type":"string","description":"Only return requests whose URL contains this substring"}},"required":[]}"#).ok(),
+        },
+        Tool {
             name: "browser_close".to_string(),
             description: "Close the browser and release all resources.".to_string(),
             inputSchema: serde_json::from_str(r#"{"type":"object","properties":{}}"#).ok(),
@@ -134,6 +150,8 @@ impl McpServer for BrowserMcpServer {
             "browser_get_text" => Some(self.handle_get_text(args).await),
             "browser_get_page_text" => Some(self.handle_get_page_text().await),
             "browser_execute_script" => Some(self.handle_execute_script(args).await),
+            "browser_read_console" => Some(self.handle_read_console(args).await),
+            "browser_read_network" => Some(self.handle_read_network(args).await),
             "browser_close" => Some(self.handle_close().await),
             _ => None,
         }
@@ -185,6 +203,48 @@ impl BrowserMcpServer {
                     }
                 };
 
+                // Capture console + network BEFORE navigating, so the start
+                // page's logs/requests are recorded.
+                let console = Arc::new(Mutex::new(Vec::<String>::new()));
+                let network = Arc::new(Mutex::new(Vec::<String>::new()));
+
+                if let Ok(mut events) = page.event_listener::<EventConsoleApiCalled>().await {
+                    let buf = console.clone();
+                    tokio::spawn(async move {
+                        while let Some(ev) = events.next().await {
+                            let line = ev
+                                .args
+                                .iter()
+                                .filter_map(|a| {
+                                    a.value
+                                        .as_ref()
+                                        .map(|v| v.to_string())
+                                        .or_else(|| a.description.clone())
+                                })
+                                .collect::<Vec<_>>()
+                                .join(" ");
+                            let mut b = buf.lock().await;
+                            if b.len() < 1000 {
+                                b.push(line);
+                            }
+                        }
+                    });
+                }
+
+                let _ = page.execute(NetworkEnableParams::default()).await;
+                if let Ok(mut events) = page.event_listener::<EventRequestWillBeSent>().await {
+                    let buf = network.clone();
+                    tokio::spawn(async move {
+                        while let Some(ev) = events.next().await {
+                            let line = format!("{} {}", ev.request.method, ev.request.url);
+                            let mut b = buf.lock().await;
+                            if b.len() < 1000 {
+                                b.push(line);
+                            }
+                        }
+                    });
+                }
+
                 // Navigate to start URL if provided
                 if let Some(url) = &start_url {
                     if let Err(e) = page.goto(url).await {
@@ -196,6 +256,8 @@ impl BrowserMcpServer {
                 *guard = Some(BrowserInstance {
                     browser,
                     page,
+                    console,
+                    network,
                 });
 
                 ToolResult::json(&serde_json::json!({
@@ -448,6 +510,44 @@ impl BrowserMcpServer {
             }
             Err(e) => ToolResult::error(format!("Script execution failed: {}", e)),
         }
+    }
+
+    async fn handle_read_console(&self, args: Value) -> ToolResult {
+        let pattern = param_str(&args, "pattern");
+        let guard = match self.get_browser().await {
+            Ok(g) => g,
+            Err(e) => return ToolResult::error(e),
+        };
+        let instance = guard.as_ref().unwrap();
+        let msgs = instance.console.lock().await;
+        let filtered: Vec<&String> = msgs
+            .iter()
+            .filter(|m| pattern.as_ref().map(|p| m.contains(p)).unwrap_or(true))
+            .collect();
+        ToolResult::json(&serde_json::json!({
+            "success": true,
+            "count": filtered.len(),
+            "messages": filtered,
+        }))
+    }
+
+    async fn handle_read_network(&self, args: Value) -> ToolResult {
+        let pattern = param_str(&args, "pattern");
+        let guard = match self.get_browser().await {
+            Ok(g) => g,
+            Err(e) => return ToolResult::error(e),
+        };
+        let instance = guard.as_ref().unwrap();
+        let reqs = instance.network.lock().await;
+        let filtered: Vec<&String> = reqs
+            .iter()
+            .filter(|m| pattern.as_ref().map(|p| m.contains(p)).unwrap_or(true))
+            .collect();
+        ToolResult::json(&serde_json::json!({
+            "success": true,
+            "count": filtered.len(),
+            "requests": filtered,
+        }))
     }
 
     async fn handle_close(&self) -> ToolResult {

--- a/cli/src/mcp/browser.rs
+++ b/cli/src/mcp/browser.rs
@@ -123,6 +123,11 @@ fn tools_list() -> Vec<Tool> {
             inputSchema: serde_json::from_str(r#"{"type":"object","properties":{"pattern":{"type":"string","description":"Only return requests whose URL contains this substring"}},"required":[]}"#).ok(),
         },
         Tool {
+            name: "browser_read_a11y".to_string(),
+            description: "Read a semantic accessibility snapshot of the page: visible interactive/landmark elements as {role, name, x, y} (click coordinates). Like an accessibility tree — for reliable, non-pixel element targeting.".to_string(),
+            inputSchema: serde_json::from_str(r#"{"type":"object","properties":{},"required":[]}"#).ok(),
+        },
+        Tool {
             name: "browser_close".to_string(),
             description: "Close the browser and release all resources.".to_string(),
             inputSchema: serde_json::from_str(r#"{"type":"object","properties":{}}"#).ok(),
@@ -152,6 +157,7 @@ impl McpServer for BrowserMcpServer {
             "browser_execute_script" => Some(self.handle_execute_script(args).await),
             "browser_read_console" => Some(self.handle_read_console(args).await),
             "browser_read_network" => Some(self.handle_read_network(args).await),
+            "browser_read_a11y" => Some(self.handle_read_a11y().await),
             "browser_close" => Some(self.handle_close().await),
             _ => None,
         }
@@ -548,6 +554,48 @@ impl BrowserMcpServer {
             "count": filtered.len(),
             "requests": filtered,
         }))
+    }
+
+    async fn handle_read_a11y(&self) -> ToolResult {
+        let guard = match self.get_browser().await {
+            Ok(g) => g,
+            Err(e) => return ToolResult::error(e),
+        };
+        let instance = guard.as_ref().unwrap();
+        // Semantic accessibility snapshot via the page: role + accessible name +
+        // click coordinates for visible interactive/landmark elements. Gives the
+        // agent a non-pixel, role-based view of the page (like an a11y tree).
+        let js = r#"
+            (() => {
+                const roleOf = (el) => {
+                    const r = el.getAttribute('role'); if (r) return r;
+                    const t = el.tagName.toLowerCase();
+                    const m = {a:'link',button:'button',input:(el.type||'textbox'),select:'combobox',
+                               textarea:'textbox',h1:'heading',h2:'heading',h3:'heading',
+                               nav:'navigation',main:'main',img:'img',label:'label'};
+                    return m[t] || (el.hasAttribute('onclick') ? 'button' : null);
+                };
+                const nameOf = (el) => (el.getAttribute('aria-label') || el.getAttribute('placeholder')
+                    || el.getAttribute('alt') || (el.innerText||'').trim().slice(0,80) || el.value || '').trim();
+                const out = [];
+                document.querySelectorAll('a,button,input,select,textarea,[role],h1,h2,h3,nav,main,label,[onclick]')
+                  .forEach(el => {
+                    const role = roleOf(el); if (!role) return;
+                    const rc = el.getBoundingClientRect();
+                    if (rc.width === 0 && rc.height === 0) return;
+                    out.push({role, name: nameOf(el),
+                              x: Math.round(rc.left + rc.width/2), y: Math.round(rc.top + rc.height/2)});
+                  });
+                return JSON.stringify(out.slice(0, 200));
+            })()
+        "#;
+        match instance.page.evaluate(js).await {
+            Ok(result) => {
+                let tree = result.value().and_then(|v| v.as_str()).unwrap_or("[]").to_string();
+                ToolResult::json(&serde_json::json!({ "success": true, "elements": tree }))
+            }
+            Err(e) => ToolResult::error(format!("Failed to read a11y tree: {}", e)),
+        }
     }
 
     async fn handle_close(&self) -> ToolResult {

--- a/cli/src/mcp/browser.rs
+++ b/cli/src/mcp/browser.rs
@@ -17,7 +17,9 @@
 use crate::mcp::{
     param_bool_or, param_str, param_u64_or, ContentItem, McpServer, Tool, ToolResult,
 };
-use chromiumoxide::cdp::browser_protocol::network::{EnableParams as NetworkEnableParams, EventRequestWillBeSent};
+use chromiumoxide::cdp::browser_protocol::network::{
+    EnableParams as NetworkEnableParams, EventRequestWillBeSent,
+};
 use chromiumoxide::cdp::js_protocol::runtime::EventConsoleApiCalled;
 use futures::StreamExt;
 use serde_json::Value;

--- a/cli/src/mcp/browser.rs
+++ b/cli/src/mcp/browser.rs
@@ -593,8 +593,12 @@ impl BrowserMcpServer {
         "#;
         match instance.page.evaluate(js).await {
             Ok(result) => {
-                let tree = result.value().and_then(|v| v.as_str()).unwrap_or("[]").to_string();
-                ToolResult::json(&serde_json::json!({ "success": true, "elements": tree }))
+                // The page returns the snapshot as a JSON string; decode it so
+                // `elements` is a real array, not a JSON-encoded string.
+                let tree_str = result.value().and_then(|v| v.as_str()).unwrap_or("[]");
+                let elements: Value =
+                    serde_json::from_str(tree_str).unwrap_or_else(|_| Value::Array(Vec::new()));
+                ToolResult::json(&serde_json::json!({ "success": true, "elements": elements }))
             }
             Err(e) => ToolResult::error(format!("Failed to read a11y tree: {}", e)),
         }


### PR DESCRIPTION
Fixes #500

## What

Fixes the `gal-browser` MCP server's page-JS execution and adds three observation primitives.

### Fix — CDP eval
`browser_get_text`, `browser_get_page_text`, `browser_execute_script`, and the type-verify
path passed IIFE expressions to chromiumoxide's `evaluate_function`, which sets the string as a
`functionDeclaration` for `Runtime.callFunctionOn` — so CDP rejected every call with
`-32000 "Given expression does not evaluate to a function"`. These now route through
`page.evaluate` (`Runtime.evaluate`); genuine function declarations still use `evaluate_function`.

### New — observation primitives
- `browser_read_console` — captures `Runtime.consoleAPICalled`
- `browser_read_network` — captures `Network.requestWillBeSent` (method + URL only)
- `browser_read_a11y` — semantic snapshot `{role, name, x, y}` for visible interactive/landmark
  elements (non-pixel targeting); returned as a real JSON array

Console/network buffers are bounded (cap 1000); listener tasks terminate on browser close/relaunch.

## Verify
- `cargo build` + `cargo build --no-default-features` + `cargo test` → **62 passed / 0 failed**
- e2e over MCP stdio against a fixture page: page-read/script tools return correct values;
  console (`FIXTURE_CONSOLE_OK`), network (`GET …`), and a11y (role+name+coords) capture confirmed
