### PR TITLE
gal-browser: set render viewport to requested size (HD screenshots)

### DIFF
--- a/cli/src/mcp/browser.rs
+++ b/cli/src/mcp/browser.rs
@@ -20,6 +20,7 @@ use crate::mcp::{
 use chromiumoxide::cdp::browser_protocol::network::{
     EnableParams as NetworkEnableParams, EventRequestWillBeSent,
 };
+use chromiumoxide::cdp::browser_protocol::emulation::SetDeviceMetricsOverrideParams;
 use chromiumoxide::cdp::js_protocol::runtime::EventConsoleApiCalled;
 use futures::StreamExt;
 use serde_json::Value;
@@ -210,6 +211,19 @@ impl BrowserMcpServer {
                         return ToolResult::error(format!("Failed to create page: {}", e));
                     }
                 };
+
+                // Match the render viewport to the requested size. Headless Chrome's
+                // viewport otherwise defaults to 800x600 regardless of window_size, so
+                // screenshots came out small — too low-res for HD captures/demos.
+                if let Ok(metrics) = SetDeviceMetricsOverrideParams::builder()
+                    .width(width as i64)
+                    .height(height as i64)
+                    .device_scale_factor(1.0)
+                    .mobile(false)
+                    .build()
+                {
+                    let _ = page.execute(metrics).await;
+                }
 
                 // Capture console + network BEFORE navigating, so the start
                 // page's logs/requests are recorded.


### PR DESCRIPTION
Fixes #508

## What
`browser_launch` set `window_size` but not the headless **render viewport** — which defaults to 800×600 — so every `browser_screenshot` was 800×600 regardless of the requested `width`/`height`. This makes gal-browser unusable for HD captures/demos.

Fix: after page creation, set `Emulation.setDeviceMetricsOverride` to the requested size (device_scale_factor 1.0).

## Verify
Built locally (release) and ran over MCP stdio: `browser_launch` at 1920×1080 → `browser_screenshot` now returns a **1920×1080** PNG (was 800×600). `cargo build` green.
