### PR TITLE
Make governance enforcement decision real (evaluate Policy.Rules)

### DIFF
--- a/services/governance-svc/cmd/server/main.go
+++ b/services/governance-svc/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/jwtauth/v5"
 
 	"github.com/gal-run/gal/services/governance-svc/internal/domain"
+	"github.com/gal-run/gal/services/governance-svc/internal/enforce"
 	"github.com/gal-run/gal/services/governance-svc/internal/store"
 	"github.com/gal-run/gal/services/lib/auth"
 	"github.com/gal-run/gal/services/lib/handler"
@@ -1202,37 +1203,7 @@ func (s *governanceSvc) enforcementCheck(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Evaluate request action against policy rules.
-	// A real implementation would parse the JSON rules and evaluate conditions.
-	// For now, we check enforcement mode.
-	var result domain.EnforcementCheckResult
-	switch activePolicy.Enforcement {
-	case "strict":
-		result = domain.EnforcementCheckResult{
-			Allowed:    false,
-			Action:     "denied",
-			PolicyID:   activePolicy.ID,
-			PolicyName: activePolicy.Name,
-			Reason:     "strict enforcement: action requires explicit approval",
-		}
-	case "disabled":
-		result = domain.EnforcementCheckResult{
-			Allowed:    true,
-			Action:     "allowed",
-			PolicyID:   activePolicy.ID,
-			PolicyName: activePolicy.Name,
-			Reason:     "policy enforcement disabled",
-		}
-	default:
-		// advisory
-		result = domain.EnforcementCheckResult{
-			Allowed:    true,
-			Action:     "audit",
-			PolicyID:   activePolicy.ID,
-			PolicyName: activePolicy.Name,
-			Reason:     "advisory mode: action allowed but will be audited",
-		}
-	}
+	result := enforce.EvaluatePolicyDecision(*activePolicy, req)
 
 	handler.RespondJSON(w, http.StatusOK, result)
 }

--- a/services/governance-svc/internal/domain/types.go
+++ b/services/governance-svc/internal/domain/types.go
@@ -146,6 +146,39 @@ type DomainAuditEntry struct {
 	CreatedAt time.Time `json:"createdAt" firestore:"createdAt"`
 }
 
+// RuleMatch defines the match conditions for a single governance rule.
+// A rule matches a request when ALL non-empty/absent match fields match the
+// corresponding request field. An empty/absent match field is a wildcard
+// that matches everything.
+//
+// Matching semantics (applied after lowercasing both the pattern and the
+// request field):
+//   - "*" matches anything (universal wildcard).
+//   - A pattern ending with "*" is a prefix match (e.g. "delete*" matches "delete-branch").
+//   - A pattern starting with "*" is a suffix match (e.g. "*release" matches "cut-release").
+//   - Otherwise the pattern must be an exact, case-insensitive match.
+//
+// All three fields (Action, Repo, Context) are independent; if a field is
+// empty it matches anything.
+type RuleMatch struct {
+	Action  string `json:"action,omitempty"`
+	Repo    string `json:"repo,omitempty"`
+	Context string `json:"context,omitempty"`
+}
+
+// Rule is a single governance rule: when the match fires, the effect applies.
+type Rule struct {
+	Match  RuleMatch `json:"match"`
+	Effect string    `json:"effect"`   // allow, deny, audit
+	Reason string    `json:"reason,omitempty"`
+}
+
+// RuleSet is the JSON schema for Policy.Rules.
+type RuleSet struct {
+	Rules   []Rule `json:"rules"`
+	Default string `json:"default,omitempty"` // allow or deny; "allow" if unset
+}
+
 // EnforcementCheckRequest is the payload for checking enforcement decisions.
 type EnforcementCheckRequest struct {
 	Action  string `json:"action"`

--- a/services/governance-svc/internal/enforce/evaluate.go
+++ b/services/governance-svc/internal/enforce/evaluate.go
@@ -1,0 +1,198 @@
+// Package enforce evaluates governance policy rules against enforcement
+// check requests. It is a pure, testable library with no HTTP or store
+// dependencies.
+package enforce
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gal-run/gal/services/governance-svc/internal/domain"
+)
+
+// EvaluatePolicyDecision evaluates a governance policy against an enforcement
+// check request and returns the final enforcement decision.
+//
+// The decision is the result of:
+//  1. Parsing p.Rules (JSON). If malformed: fail-closed (treated as an implicit
+//     "deny" outcome before mode combination).
+//  2. Scanning the parsed rules in order. The first matching rule's Effect wins.
+//     If no rule matches, the ruleset's Default is used ("allow" if unset).
+//  3. Combining the matched effect with p.Enforcement mode:
+//     - "disabled"  → always Allowed:true, Action:"allowed" (mode overrides rules).
+//     - "strict"    → "deny"  → Allowed:false, Action:"denied"
+//                      "audit" → Allowed:true,  Action:"audit"
+//                      "allow" → Allowed:true,  Action:"allowed"
+//     - "advisory"  → "deny"  → downgraded to Allowed:true, Action:"audit"
+//                      "audit" → Allowed:true, Action:"audit"
+//                      "allow" → Allowed:true, Action:"allowed"
+func EvaluatePolicyDecision(p domain.Policy, req domain.EnforcementCheckRequest) domain.EnforcementCheckResult {
+	// Step 1: Parse Rules JSON. Fail-closed on malformed data.
+	ruleset, parseErr := parseRules(p.Rules)
+	if parseErr != nil {
+		return failClosedResult(p, parseErr)
+	}
+
+	// Step 2: Evaluate rules. First match wins.
+	matchedEffect, matchedReason := evaluateRules(ruleset, req)
+
+	// Step 3: Combine with enforcement mode.
+	return combineWithMode(p, matchedEffect, matchedReason)
+}
+
+// parseRules unmarshals a JSON RuleSet string.
+func parseRules(raw string) (domain.RuleSet, error) {
+	if raw == "" {
+		return domain.RuleSet{Rules: nil, Default: "allow"}, nil
+	}
+	var rs domain.RuleSet
+	if err := json.Unmarshal([]byte(raw), &rs); err != nil {
+		return domain.RuleSet{}, fmt.Errorf("malformed rules JSON: %w", err)
+	}
+	// Normalise: nil -> empty slice for deterministic iteration.
+	if rs.Rules == nil {
+		rs.Rules = []domain.Rule{}
+	}
+	return rs, nil
+}
+
+// evaluateRules scans the rules in order. Returns the first matching rule's
+// effect and reason. If no rule matches, returns the default effect.
+func evaluateRules(rs domain.RuleSet, req domain.EnforcementCheckRequest) (effect, reason string) {
+	for _, rule := range rs.Rules {
+		if matchRule(rule.Match, req) {
+			return rule.Effect, rule.Reason
+		}
+	}
+	// Default: "allow" if unset.
+	def := rs.Default
+	if def == "" {
+		def = "allow"
+	}
+	return def, fmt.Sprintf("default policy (%s) — no matching rule", def)
+}
+
+// matchRule returns true when ALL non-empty match fields match the request.
+func matchRule(m domain.RuleMatch, req domain.EnforcementCheckRequest) bool {
+	return fieldMatches(m.Action, req.Action) &&
+		fieldMatches(m.Repo, req.Repo) &&
+		fieldMatches(m.Context, req.Context)
+}
+
+// fieldMatches checks whether pattern p matches value v.
+// Matching is case-insensitive. An empty pattern is a wildcard (matches
+// everything).
+//
+// Semantics:
+//   - "*" -> matches everything.
+//   - Trailing "*" -> prefix match (e.g. "git*" matches "git push").
+//   - Leading "*" -> suffix match (e.g. "*merge" matches "squash-merge").
+//   - Otherwise -> exact (case-insensitive) match.
+func fieldMatches(pattern, value string) bool {
+	if pattern == "" {
+		return true
+	}
+	p := strings.ToLower(pattern)
+	v := strings.ToLower(value)
+	if p == "*" {
+		return true
+	}
+	if strings.HasPrefix(p, "*") && strings.HasSuffix(p, "*") {
+		// Both prefix and suffix wildcard — substring match.
+		return strings.Contains(v, p[1:len(p)-1])
+	}
+	if strings.HasPrefix(p, "*") {
+		return strings.HasSuffix(v, p[1:])
+	}
+	if strings.HasSuffix(p, "*") {
+		return strings.HasPrefix(v, p[:len(p)-1])
+	}
+	return p == v
+}
+
+// combineWithMode combines the matched rule effect with the policy's
+// enforcement mode to produce the final EnforcementCheckResult.
+func combineWithMode(p domain.Policy, effect, reason string) domain.EnforcementCheckResult {
+	// Build a base reason that names the policy.
+	baseReason := reason
+	if baseReason == "" {
+		baseReason = fmt.Sprintf("policy %q rule matched", p.Name)
+	}
+
+	switch p.Enforcement {
+	case "disabled":
+		return domain.EnforcementCheckResult{
+			Allowed:    true,
+			Action:     "allowed",
+			PolicyID:   p.ID,
+			PolicyName: p.Name,
+			Reason:     fmt.Sprintf("policy enforcement disabled (rule would: %s — %s)", effect, baseReason),
+		}
+
+	case "strict":
+		switch effect {
+		case "deny":
+			return domain.EnforcementCheckResult{
+				Allowed:    false,
+				Action:     "denied",
+				PolicyID:   p.ID,
+				PolicyName: p.Name,
+				Reason:     fmt.Sprintf("strict enforcement: denied — %s", baseReason),
+			}
+		case "audit":
+			return domain.EnforcementCheckResult{
+				Allowed:    true,
+				Action:     "audit",
+				PolicyID:   p.ID,
+				PolicyName: p.Name,
+				Reason:     fmt.Sprintf("strict enforcement: audit — %s", baseReason),
+			}
+		default: // "allow"
+			return domain.EnforcementCheckResult{
+				Allowed:    true,
+				Action:     "allowed",
+				PolicyID:   p.ID,
+				PolicyName: p.Name,
+				Reason:     fmt.Sprintf("strict enforcement: allowed — %s", baseReason),
+			}
+		}
+
+	default: // "advisory" (including any unrecognised mode)
+		switch effect {
+		case "deny":
+			return domain.EnforcementCheckResult{
+				Allowed:    true,
+				Action:     "audit",
+				PolicyID:   p.ID,
+				PolicyName: p.Name,
+				Reason:     fmt.Sprintf("advisory: would deny under strict — %s", baseReason),
+			}
+		case "audit":
+			return domain.EnforcementCheckResult{
+				Allowed:    true,
+				Action:     "audit",
+				PolicyID:   p.ID,
+				PolicyName: p.Name,
+				Reason:     fmt.Sprintf("advisory: audit — %s", baseReason),
+			}
+		default: // "allow"
+			return domain.EnforcementCheckResult{
+				Allowed:    true,
+				Action:     "allowed",
+				PolicyID:   p.ID,
+				PolicyName: p.Name,
+				Reason:     fmt.Sprintf("advisory: allowed — %s", baseReason),
+			}
+		}
+	}
+}
+
+// failClosedResult is used when the Rules JSON is malformed or unparseable.
+// It produces an implicit "deny" outcome, which combineWithMode then turns
+// into the actual denial depending on the enforcement mode.
+func failClosedResult(p domain.Policy, parseErr error) domain.EnforcementCheckResult {
+	effect := "deny"
+	reason := fmt.Sprintf("malformed rules JSON — fail-closed: %v", parseErr)
+	return combineWithMode(p, effect, reason)
+}

--- a/services/governance-svc/internal/enforce/evaluate_test.go
+++ b/services/governance-svc/internal/enforce/evaluate_test.go
@@ -1,0 +1,254 @@
+package enforce_test
+
+import (
+	"testing"
+
+	"github.com/gal-run/gal/services/governance-svc/internal/domain"
+	"github.com/gal-run/gal/services/governance-svc/internal/enforce"
+)
+
+// buildPolicy is a test helper that creates a domain.Policy with the given
+// attributes. rulesRaw is the JSON for Policy.Rules.
+func buildPolicy(id, name, enforcement, rulesRaw string) domain.Policy {
+	return domain.Policy{
+		ID:          id,
+		OrgID:       "org-1",
+		Name:        name,
+		Description: "test policy",
+		Rules:       rulesRaw,
+		Enforcement: enforcement,
+		IsActive:    true,
+	}
+}
+
+// req is a test helper for creating a request.
+func req(action, repo, context string) domain.EnforcementCheckRequest {
+	return domain.EnforcementCheckRequest{Action: action, Repo: repo, Context: context}
+}
+
+func TestEvaluatePolicyDecision_RulesDriveDecision(t *testing.T) {
+	// (a) Two policies, SAME Enforcement="strict", DIFFERENT Rules.
+	//     Same request {Action:"delete"} must produce different results.
+
+	rulesAllowDelete := `{
+		"rules": [{"match": {"action": "delete"}, "effect": "allow", "reason": "deletion allowed"}],
+		"default": "deny"
+	}`
+	rulesDenyDelete := `{
+		"rules": [{"match": {"action": "delete"}, "effect": "deny", "reason": "deletion prohibited"}],
+		"default": "allow"
+	}`
+
+	pAllow := buildPolicy("p-allow", "allow-delete", "strict", rulesAllowDelete)
+	pDeny := buildPolicy("p-deny", "deny-delete", "strict", rulesDenyDelete)
+
+	r := req("delete", "", "")
+
+	// Policy that ALLOWS delete → Allowed:true
+	result1 := enforce.EvaluatePolicyDecision(pAllow, r)
+	if result1.Allowed != true {
+		t.Errorf("expected allowed=true for policy with allow-delete rule, got allowed=%v action=%q", result1.Allowed, result1.Action)
+	}
+	if result1.Action != "allowed" {
+		t.Errorf("expected action=allowed, got %q", result1.Action)
+	}
+
+	// Policy that DENIES delete → Allowed:false
+	result2 := enforce.EvaluatePolicyDecision(pDeny, r)
+	if result2.Allowed != false {
+		t.Errorf("expected allowed=false for policy with deny-delete rule, got allowed=%v action=%q", result2.Allowed, result2.Action)
+	}
+	if result2.Action != "denied" {
+		t.Errorf("expected action=denied, got %q", result2.Action)
+	}
+}
+
+func TestEvaluatePolicyDecision_RequestPayloadMatters(t *testing.T) {
+	// (b) ONE strict policy: denies "delete", allows "read".
+	rules := `{
+		"rules": [
+			{"match": {"action": "delete"}, "effect": "deny", "reason": "no deletions"},
+			{"match": {"action": "read"},   "effect": "allow", "reason": "reads ok"}
+		],
+		"default": "audit"
+	}`
+	p := buildPolicy("p-1", "multi-rule", "strict", rules)
+
+	// Delete → denied
+	rDel := req("delete", "", "")
+	resDel := enforce.EvaluatePolicyDecision(p, rDel)
+	if resDel.Allowed != false || resDel.Action != "denied" {
+		t.Errorf("delete: expected denied, got allowed=%v action=%q", resDel.Allowed, resDel.Action)
+	}
+
+	// Read → allowed
+	rRead := req("read", "", "")
+	resRead := enforce.EvaluatePolicyDecision(p, rRead)
+	if resRead.Allowed != true || resRead.Action != "allowed" {
+		t.Errorf("read: expected allowed, got allowed=%v action=%q", resRead.Allowed, resRead.Action)
+	}
+}
+
+func TestEvaluatePolicyDecision_AdvisoryDowngradesDeny(t *testing.T) {
+	// (c) Advisory mode: a deny rule produces Allowed:true + Action:"audit".
+	rules := `{
+		"rules": [{"match": {"action": "delete"}, "effect": "deny", "reason": "no deletions"}]
+	}`
+	p := buildPolicy("p-advisory", "advisory", "advisory", rules)
+
+	rDel := req("delete", "", "")
+	result := enforce.EvaluatePolicyDecision(p, rDel)
+
+	if result.Allowed != true {
+		t.Errorf("advisory deny: expected allowed=true (downgraded), got %v", result.Allowed)
+	}
+	if result.Action != "audit" {
+		t.Errorf("advisory deny: expected action=audit, got %q", result.Action)
+	}
+}
+
+func TestEvaluatePolicyDecision_DisabledAllows(t *testing.T) {
+	// (d) Disabled mode: even a deny rule produces Allowed:true.
+	rules := `{
+		"rules": [{"match": {"action": "delete"}, "effect": "deny", "reason": "no deletions"}]
+	}`
+	p := buildPolicy("p-disabled", "disabled", "disabled", rules)
+
+	rDel := req("delete", "", "")
+	result := enforce.EvaluatePolicyDecision(p, rDel)
+
+	if result.Allowed != true {
+		t.Errorf("disabled deny: expected allowed=true, got %v", result.Allowed)
+	}
+	if result.Action != "allowed" {
+		t.Errorf("disabled deny: expected action=allowed, got %q", result.Action)
+	}
+}
+
+func TestEvaluatePolicyDecision_MalformedRules(t *testing.T) {
+	// (e) Malformed Rules JSON → no panic; fail-closed; strict mode denies.
+	p := buildPolicy("p-bad", "bad-rules", "strict", "{{{not json}}")
+
+	// Must not panic.
+	rDel := req("anything", "", "")
+	result := enforce.EvaluatePolicyDecision(p, rDel)
+
+	if result.Allowed != false {
+		t.Errorf("malformed strict: expected allowed=false (fail-closed), got %v", result.Allowed)
+	}
+	if result.Action != "denied" {
+		t.Errorf("malformed strict: expected action=denied, got %q", result.Action)
+	}
+	if result.PolicyID != "p-bad" {
+		t.Errorf("expected PolicyID=p-bad, got %q", result.PolicyID)
+	}
+
+	// Also verify advisory mode with malformed JSON does not hard-block.
+	p2 := buildPolicy("p-bad-advisory", "bad-rules-advisory", "advisory", "{{{not json}}")
+	result2 := enforce.EvaluatePolicyDecision(p2, rDel)
+	if result2.Allowed != true {
+		t.Errorf("malformed advisory: expected allowed=true (downgraded), got %v", result2.Allowed)
+	}
+	if result2.Action != "audit" {
+		t.Errorf("malformed advisory: expected action=audit, got %q", result2.Action)
+	}
+}
+
+func TestEvaluatePolicyDecision_DefaultEffect(t *testing.T) {
+	// When no rule matches, the default ("allow") must be used.
+	rules := `{
+		"rules": [{"match": {"action": "delete"}, "effect": "deny"}],
+		"default": "allow"
+	}`
+	p := buildPolicy("p-def", "with-default", "strict", rules)
+
+	// Action "push" does not match the "delete" rule → default "allow"
+	rPush := req("push", "", "")
+	result := enforce.EvaluatePolicyDecision(p, rPush)
+	if result.Allowed != true || result.Action != "allowed" {
+		t.Errorf("default allow: expected allowed, got allowed=%v action=%q", result.Allowed, result.Action)
+	}
+
+	// Default unset → defaults to "allow"
+	rulesNoDefault := `{
+		"rules": [{"match": {"action": "delete"}, "effect": "deny"}]
+	}`
+	p2 := buildPolicy("p-nodef", "no-default", "strict", rulesNoDefault)
+	result2 := enforce.EvaluatePolicyDecision(p2, rPush)
+	if result2.Allowed != true || result2.Action != "allowed" {
+		t.Errorf("unset default: expected allowed, got allowed=%v action=%q", result2.Allowed, result2.Action)
+	}
+}
+
+func TestEvaluatePolicyDecision_WildcardAndGlobMatching(t *testing.T) {
+	// Test prefix, suffix, universal wildcard, and case-insensitive matching.
+	rules := `{
+		"rules": [
+			{"match": {"action": "git*"},      "effect": "deny",  "reason": "all git ops denied"},
+			{"match": {"action": "*delete"},     "effect": "deny",  "reason": "delete-anything denied"},
+			{"match": {"action": "*"},           "effect": "allow", "reason": "everything else allowed"}
+		]
+	}`
+	p := buildPolicy("p-glob", "glob-policy", "strict", rules)
+
+	// "git push" matches prefix "git*" → denied
+	r1 := req("git push", "", "")
+	res1 := enforce.EvaluatePolicyDecision(p, r1)
+	if res1.Allowed != false {
+		t.Errorf("git push: expected denied, got allowed=%v", res1.Allowed)
+	}
+
+	// "force-delete" matches suffix "*delete" → denied
+	r2 := req("force-delete", "", "")
+	res2 := enforce.EvaluatePolicyDecision(p, r2)
+	if res2.Allowed != false {
+		t.Errorf("force-delete: expected denied, got allowed=%v", res2.Allowed)
+	}
+
+	// "read" matches "*" → allowed
+	r3 := req("read", "", "")
+	res3 := enforce.EvaluatePolicyDecision(p, r3)
+	if res3.Allowed != true {
+		t.Errorf("read: expected allowed, got allowed=%v", res3.Allowed)
+	}
+
+	// Case insensitivity: "GIT PUSH" matches "git*" → denied
+	r4 := req("GIT PUSH", "", "")
+	res4 := enforce.EvaluatePolicyDecision(p, r4)
+	if res4.Allowed != false {
+		t.Errorf("GIT PUSH (case insensitive): expected denied, got allowed=%v", res4.Allowed)
+	}
+}
+
+func TestEvaluatePolicyDecision_RepoAndContextMatch(t *testing.T) {
+	// Rules may match on repo and context too. All set fields must match.
+	rules := `{
+		"rules": [
+			{"match": {"action": "deploy", "repo": "prod*", "context": "production"}, "effect": "deny", "reason": "no prod deploys"},
+			{"match": {"action": "deploy", "repo": "staging"},                           "effect": "allow", "reason": "staging ok"}
+		],
+		"default": "audit"
+	}`
+	p := buildPolicy("p-repo", "repo-aware", "strict", rules)
+
+	// Deploy to prod-web → denied (matches repo="prod*" and context="production")
+	r1 := req("deploy", "prod-web", "production")
+	res1 := enforce.EvaluatePolicyDecision(p, r1)
+	if res1.Allowed != false || res1.Action != "denied" {
+		t.Errorf("prod deploy: expected denied, got allowed=%v action=%q", res1.Allowed, res1.Action)
+	}
+
+	// Deploy to staging → allowed (matches second rule)
+	r2 := req("deploy", "staging", "")
+	res2 := enforce.EvaluatePolicyDecision(p, r2)
+	if res2.Allowed != true || res2.Action != "allowed" {
+		t.Errorf("staging deploy: expected allowed, got allowed=%v action=%q", res2.Allowed, res2.Action)
+	}
+
+	// Deploy to prod-web with wrong context → does NOT match first rule (context mismatch), falls through to default "audit"
+	r3 := req("deploy", "prod-web", "staging")
+	res3 := enforce.EvaluatePolicyDecision(p, r3)
+	if res3.Action != "audit" {
+		t.Errorf("prod deploy with staging context: expected audit (default fallthrough), got action=%q", res3.Action)
+	}
+}


### PR DESCRIPTION
Closes #512

Replaces the stub mode-switch in governance-svc /enforcement/check with real Policy.Rules evaluation (first-match-wins, glob field matching, mode-combination, fail-closed). 8 new tests prove rules drive the decision (two policies, same mode, different rules => different verdicts). go build + test green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)