### PR TITLE
Gate 8 remaining customer-reachable dashboard pages (audience guard sweep)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/agents/new/agents-new-route-guard.test.tsx
+++ b/apps/dashboard/src/app/(dashboard)/agents/new/agents-new-route-guard.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Route-guard proof for the New Agent page (#6513).
+ *
+ * Before this fix /agents/new had ZERO route-level guard. The parent /agents
+ * list page already gates on the internal background-agents audience, but
+ * /agents/new is independently hand-typeable — a customer-tier user could open
+ * it and create/configure background-agent cards.
+ *
+ * The fix adds the canonical audience-aware guard used by /agents:
+ *   isPageVisibleForUser('background-agents', userOrgs, workspace) → FeatureGate.
+ *
+ * Proven two ways: behavioral render + grounding on the REAL @gal/core
+ * audience primitives.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { meetsAudience, resolveOrgTier } from '@gal/core'
+
+const PAGE_ID = 'background-agents'
+const DENY_COPY = 'Background agents and sessions are not available for this workspace'
+const ALLOW_MARKER = 'Define an agent that Operator Hub'
+
+const isPageVisibleForUser = vi.fn()
+
+vi.mock('@/contexts/FeatureFlagsContext', () => ({
+  useFeatureFlags: () => ({
+    isPageVisibleForUser,
+    isPageEnabled: () => true,
+    loading: false,
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { organizations: ['acme-customer'] },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/hooks/useSelectedWorkspace', () => ({
+  useSelectedWorkspace: () => 'acme-customer',
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+// Keep data lanes inert (the guard must run first anyway).
+vi.mock('@/lib/agent-card-api', () => ({ createAgentCard: vi.fn() }))
+vi.mock('@/lib/gmail-credential-api', () => ({ getGmailOAuthUrl: vi.fn() }))
+
+async function renderPage(): Promise<string> {
+  const mod = await import('./page')
+  return renderToStaticMarkup(createElement(mod.default))
+}
+
+describe('new agent route guard (#6513)', () => {
+  beforeEach(() => {
+    isPageVisibleForUser.mockReset()
+  })
+
+  it('DENIES a customer-tier user: renders FeatureGate, NOT the agent form', async () => {
+    isPageVisibleForUser.mockReturnValue(false)
+    const html = await renderPage()
+    expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+    expect(html).toContain(DENY_COPY)
+    expect(html).not.toContain(ALLOW_MARKER)
+  })
+
+  it('ALLOWS an internal/EE user: renders the agent form, NOT the FeatureGate', async () => {
+    isPageVisibleForUser.mockReturnValue(true)
+    const html = await renderPage()
+    expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+    expect(html).toContain(ALLOW_MARKER)
+    expect(html).not.toContain(DENY_COPY)
+  })
+
+  it('gates on the audience-aware resolver + FeatureGate', () => {
+    const source = readFileSync(join(__dirname, 'page.tsx'), 'utf8')
+    expect(source).toContain('import { FeatureGate } from "@/components/FeatureGate"')
+    expect(source).toContain('isPageVisibleForUser("background-agents", userOrgs, orgName)')
+    expect(source).toContain('<FeatureGate pageId="background-agents" />')
+  })
+
+  it('grounding: a customer org is genuinely denied the internal "background-agents" tier', () => {
+    const customerTier = resolveOrgTier(null, 'free')
+    const internalTier = resolveOrgTier('internal', 'free')
+    expect(meetsAudience(customerTier, 'internal')).toBe(false)
+    expect(meetsAudience(internalTier, 'internal')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/app/(dashboard)/agents/new/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/agents/new/page.tsx
@@ -17,6 +17,9 @@ import {
   Trash2,
 } from "lucide-react";
 import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import { createAgentCard } from "@/lib/agent-card-api";
 import type { CreateAgentCardRequest } from "@/lib/agent-card-api";
 import { getGmailOAuthUrl } from "@/lib/gmail-credential-api";
@@ -53,6 +56,9 @@ const TOOL_OPTIONS = [
 export default function NewAgentPage() {
   const router = useRouter();
   const orgName = useSelectedWorkspace();
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
 
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
@@ -126,6 +132,14 @@ export default function NewAgentPage() {
       setLoading(false);
     }
   };
+
+  // Route guard (#6513): creating background-agent cards is part of the
+  // internal background-agents surface (same as the parent /agents list). Block
+  // non-internal/non-EE (customer-tier) users who hand-type /agents/new with
+  // the same audience-aware FeatureGate the /agents page uses.
+  if (!isPageVisibleForUser("background-agents", userOrgs, orgName)) {
+    return <FeatureGate pageId="background-agents" />;
+  }
 
   if (!orgName) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/compliance/sdlc/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/compliance/sdlc/page.tsx
@@ -13,6 +13,8 @@ import {
   GitPullRequest,
 } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
+import { useFeatureFlags } from '@/contexts/FeatureFlagsContext'
+import { FeatureGate } from '@/components/FeatureGate'
 import { useSelectedWorkspace } from '@/hooks/useSelectedWorkspace'
 import { api } from '@/lib/api'
 import type { SdlcComplianceStatus, SdlcDriftReport } from '@/lib/api'
@@ -49,6 +51,7 @@ function getScoreLabel(score: number): string {
 
 export default function SdlcCompliancePage() {
   const { user } = useAuth()
+  const { isPageVisibleForUser } = useFeatureFlags()
   const selectedWorkspace = useSelectedWorkspace()
   const userOrgs = user?.organizations ?? []
   const orgName = selectedWorkspace ?? userOrgs[0] ?? null
@@ -85,6 +88,15 @@ export default function SdlcCompliancePage() {
   useEffect(() => {
     fetchData()
   }, [fetchData])
+
+  // Route guard (#4029): SDLC compliance is internal-only (mirrors the
+  // /compliance/developers sibling and the layout nav, which both map this
+  // surface to the internal 'enforcement-overrides' page). Block
+  // non-internal/non-EE (customer-tier) users who hand-type /compliance/sdlc
+  // with the same audience-aware FeatureGate the enforcement pages use.
+  if (!isPageVisibleForUser('enforcement-overrides', userOrgs, selectedWorkspace)) {
+    return <FeatureGate pageId="enforcement-overrides" />
+  }
 
   if (!orgName) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/compliance/sdlc/sdlc-route-guard.test.tsx
+++ b/apps/dashboard/src/app/(dashboard)/compliance/sdlc/sdlc-route-guard.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Route-guard proof for the SDLC compliance page (#4029).
+ *
+ * Before this fix /compliance/sdlc had ZERO route-level guard — unlike its
+ * sibling /compliance/developers, which already gates on the internal
+ * workspace. SDLC compliance is internal-only (the layout nav maps it to the
+ * internal `enforcement-overrides` page), yet a customer-tier user who
+ * hand-typed /compliance/sdlc rendered the full compliance dashboard.
+ *
+ * The fix adds the canonical audience-aware guard:
+ *   isPageVisibleForUser('enforcement-overrides', userOrgs, workspace) → FeatureGate.
+ *
+ * Proven two ways: behavioral render + grounding on the REAL @gal/core
+ * audience primitives.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { meetsAudience, resolveOrgTier } from '@gal/core'
+
+const PAGE_ID = 'enforcement-overrides'
+const DENY_COPY = 'Enforcement overrides are only available to internal users'
+// After the guard passes the page renders its loading spinner (animate-spin),
+// never the deny copy.
+const ALLOW_MARKER = 'animate-spin'
+
+const isPageVisibleForUser = vi.fn()
+
+vi.mock('@/contexts/FeatureFlagsContext', () => ({
+  useFeatureFlags: () => ({
+    isPageVisibleForUser,
+    isPageEnabled: () => true,
+    loading: false,
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { organizations: ['acme-customer'] },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/hooks/useSelectedWorkspace', () => ({
+  useSelectedWorkspace: () => 'acme-customer',
+}))
+
+vi.mock('@/lib/demo-guard', () => ({ isDemoMode: () => false }))
+
+async function renderPage(): Promise<string> {
+  const mod = await import('./page')
+  return renderToStaticMarkup(createElement(mod.default))
+}
+
+describe('sdlc compliance route guard (#4029)', () => {
+  beforeEach(() => {
+    isPageVisibleForUser.mockReset()
+  })
+
+  it('DENIES a customer-tier user: renders FeatureGate, NOT the compliance dashboard', async () => {
+    isPageVisibleForUser.mockReturnValue(false)
+    const html = await renderPage()
+    expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+    expect(html).toContain(DENY_COPY)
+    expect(html).not.toContain(ALLOW_MARKER)
+  })
+
+  it('ALLOWS an internal/EE user: renders the compliance dashboard, NOT the FeatureGate', async () => {
+    isPageVisibleForUser.mockReturnValue(true)
+    const html = await renderPage()
+    expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+    expect(html).toContain(ALLOW_MARKER)
+    expect(html).not.toContain(DENY_COPY)
+  })
+
+  it('gates on the audience-aware resolver + FeatureGate', () => {
+    const source = readFileSync(join(__dirname, 'page.tsx'), 'utf8')
+    expect(source).toContain("import { FeatureGate } from '@/components/FeatureGate'")
+    expect(source).toContain("isPageVisibleForUser('enforcement-overrides', userOrgs, selectedWorkspace)")
+    expect(source).toContain('<FeatureGate pageId="enforcement-overrides" />')
+  })
+
+  it('grounding: a customer org is genuinely denied the internal "enforcement-overrides" tier', () => {
+    const customerTier = resolveOrgTier(null, 'free')
+    const internalTier = resolveOrgTier('internal', 'free')
+    expect(meetsAudience(customerTier, 'internal')).toBe(false)
+    expect(meetsAudience(internalTier, 'internal')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/app/(dashboard)/evals/[suiteId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/evals/[suiteId]/page.tsx
@@ -15,6 +15,9 @@ import {
   XCircle,
 } from "lucide-react";
 import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import { getEvalReport, runEval } from "@/lib/eval-api";
 import type { EvalReport } from "@/lib/eval-api";
 import { isDemoMode } from "@/lib/demo-guard";
@@ -35,6 +38,9 @@ export default function EvalDetailPage() {
   const suiteId = typeof params.suiteId === "string" ? params.suiteId : (params.suiteId as string[])?.[0] ?? "";
   const workspaceName = useSelectedWorkspace();
   const orgName = isDemoMode() ? workspaceName ?? DEMO_ORG : workspaceName;
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
 
   const [report, setReport] = useState<EvalReport | null>(null);
   const [loading, setLoading] = useState(true);
@@ -71,6 +77,14 @@ export default function EvalDetailPage() {
       setRunning(false);
     }
   };
+
+  // Route guard (#6513): the eval suite detail page is part of the internal
+  // background-agents surface. Block non-internal/non-EE (customer-tier) users
+  // who hand-type /evals/<suiteId> with the same audience-aware FeatureGate the
+  // agents/sessions pages use.
+  if (!isPageVisibleForUser("background-agents", userOrgs, workspaceName)) {
+    return <FeatureGate pageId="background-agents" />;
+  }
 
   if (loading) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/evals/evals-route-guard.test.tsx
+++ b/apps/dashboard/src/app/(dashboard)/evals/evals-route-guard.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Route-guard proof for the Evals surface (#6513).
+ *
+ * Before this fix both /evals (the suite list) and /evals/[suiteId] (the suite
+ * detail) had ZERO route-level guard. The evals dashboard is part of the
+ * internal background-agents surface (agents must pass eval gates before
+ * deployment) — the layout nav maps /evals to the internal `background-agents`
+ * page — yet a customer-tier user who hand-typed /evals rendered the dashboard
+ * and could trigger eval runs.
+ *
+ * The fix adds the canonical audience-aware guard used by the /agents and
+ * /sessions pages:
+ *   isPageVisibleForUser('background-agents', userOrgs, workspace) → FeatureGate.
+ *
+ * Proven two ways: behavioral render (customer → deny, internal → content) and
+ * grounding on the REAL @gal/core audience primitives.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { meetsAudience, resolveOrgTier } from '@gal/core'
+
+const PAGE_ID = 'background-agents'
+const DENY_COPY = 'Background agents and sessions are not available for this workspace'
+
+const isPageVisibleForUser = vi.fn()
+
+vi.mock('@/contexts/FeatureFlagsContext', () => ({
+  useFeatureFlags: () => ({
+    isPageVisibleForUser,
+    isPageEnabled: () => true,
+    loading: false,
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { organizations: ['acme-customer'] },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/hooks/useSelectedWorkspace', () => ({
+  useSelectedWorkspace: () => 'acme-customer',
+}))
+
+// Not demo mode — exercise the real customer/internal split.
+vi.mock('@/lib/demo-guard', () => ({ isDemoMode: () => false }))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ suiteId: 'suite-123' }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/lib/eval-api', () => ({
+  listEvalSuites: vi.fn().mockResolvedValue([]),
+  getEvalReport: vi.fn().mockResolvedValue(null),
+  runEval: vi.fn(),
+}))
+
+async function renderPage(importer: () => Promise<{ default: () => unknown }>): Promise<string> {
+  const mod = await importer()
+  return renderToStaticMarkup(createElement(mod.default as () => any))
+}
+
+const PAGES: { name: string; importer: () => Promise<any>; allowMarker: string }[] = [
+  {
+    name: 'evals list',
+    importer: () => import('./page'),
+    // After the guard passes the list renders its loading skeleton first.
+    allowMarker: 'animate-pulse',
+  },
+  {
+    name: 'eval suite detail',
+    importer: () => import('./[suiteId]/page'),
+    allowMarker: 'animate-pulse',
+  },
+]
+
+describe('evals route guard (#6513)', () => {
+  beforeEach(() => {
+    isPageVisibleForUser.mockReset()
+    vi.resetModules()
+  })
+
+  for (const page of PAGES) {
+    it(`DENIES a customer-tier user on the ${page.name} page (FeatureGate, not content)`, async () => {
+      isPageVisibleForUser.mockReturnValue(false)
+      const html = await renderPage(page.importer)
+      expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+      expect(html).toContain(DENY_COPY)
+      expect(html).not.toContain(page.allowMarker)
+    })
+
+    it(`ALLOWS an internal/EE user on the ${page.name} page (content, not FeatureGate)`, async () => {
+      isPageVisibleForUser.mockReturnValue(true)
+      const html = await renderPage(page.importer)
+      expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+      expect(html).toContain(page.allowMarker)
+      expect(html).not.toContain(DENY_COPY)
+    })
+  }
+
+  it('both evals pages gate on the audience-aware resolver + FeatureGate', () => {
+    for (const rel of ['page.tsx', '[suiteId]/page.tsx']) {
+      const source = readFileSync(join(__dirname, rel), 'utf8')
+      expect(source).toContain('import { FeatureGate } from "@/components/FeatureGate"')
+      expect(source).toContain('isPageVisibleForUser("background-agents", userOrgs, workspaceName)')
+      expect(source).toContain('<FeatureGate pageId="background-agents" />')
+    }
+  })
+
+  it('grounding: a customer org is genuinely denied the internal "background-agents" tier', () => {
+    const customerTier = resolveOrgTier(null, 'free')
+    const internalTier = resolveOrgTier('internal', 'free')
+    expect(meetsAudience(customerTier, 'internal')).toBe(false)
+    expect(meetsAudience(internalTier, 'internal')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/app/(dashboard)/evals/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/evals/page.tsx
@@ -15,6 +15,9 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import { listEvalSuites, runEval } from "@/lib/eval-api";
 import type { EvalSuiteSummary } from "@/lib/eval-api";
 import { isDemoMode } from "@/lib/demo-guard";
@@ -52,6 +55,9 @@ function ScoreBadge({ score, passed }: { score: number; passed: boolean }) {
 export default function EvalsPage() {
   const workspaceName = useSelectedWorkspace();
   const orgName = isDemoMode() ? workspaceName ?? DEMO_ORG : workspaceName;
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
 
   const [suites, setSuites] = useState<EvalSuiteSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -101,6 +107,14 @@ export default function EvalsPage() {
         : suites.reduce((sum, s) => sum + (s.latestReport?.score ?? 0), 0) / total;
     return { total, passing, avgScore };
   }, [suites]);
+
+  // Route guard (#6513): the evals dashboard is part of the internal
+  // background-agents surface (agents must pass eval gates before deployment).
+  // Block non-internal/non-EE (customer-tier) users who hand-type /evals with
+  // the same audience-aware FeatureGate the agents/sessions pages use.
+  if (!isPageVisibleForUser("background-agents", userOrgs, workspaceName)) {
+    return <FeatureGate pageId="background-agents" />;
+  }
 
   if (loading) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/policies/[policyId]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/policies/[policyId]/page.tsx
@@ -13,6 +13,9 @@ import {
   Check,
 } from "lucide-react";
 import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import {
   getPolicy,
   updatePolicy,
@@ -27,6 +30,9 @@ export default function PolicyDetailPage() {
   const params = useParams();
   const policyId = params?.policyId as string;
   const orgName = useSelectedWorkspace();
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
 
   const [policy, setPolicy] = useState<Policy | null>(null);
   const [loading, setLoading] = useState(true);
@@ -126,6 +132,13 @@ export default function PolicyDetailPage() {
       setShowDeleteConfirm(false);
     }
   };
+
+  // Route guard (#6878): governance policies are internal-only. Block
+  // non-internal/non-EE (customer-tier) users who hand-type /policies/<id> with
+  // the same audience-aware FeatureGate the agents/enforcement pages use.
+  if (!isPageVisibleForUser("policies", userOrgs, orgName)) {
+    return <FeatureGate pageId="policies" />;
+  }
 
   if (loading) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/policies/check/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/policies/check/page.tsx
@@ -2,9 +2,25 @@
 
 import Link from "next/link";
 import { ArrowLeft, Play, Shield } from "lucide-react";
+import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import { PolicyCheckForm } from "@/components/policies/PolicyCheckForm";
 
 export default function PolicyCheckPage() {
+  const orgName = useSelectedWorkspace();
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
+
+  // Route guard (#6878): governance policies are internal-only. Block
+  // non-internal/non-EE (customer-tier) users who hand-type /policies/check with
+  // the same audience-aware FeatureGate the agents/enforcement pages use.
+  if (!isPageVisibleForUser("policies", userOrgs, orgName)) {
+    return <FeatureGate pageId="policies" />;
+  }
+
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="flex items-center gap-4 mb-8">

--- a/apps/dashboard/src/app/(dashboard)/policies/new/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/policies/new/page.tsx
@@ -5,11 +5,17 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Shield, Loader2, AlertCircle } from "lucide-react";
 import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import { createPolicy } from "@/lib/policy-api";
 
 export default function NewPolicyPage() {
   const router = useRouter();
   const orgName = useSelectedWorkspace();
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -39,6 +45,13 @@ export default function NewPolicyPage() {
       setLoading(false);
     }
   };
+
+  // Route guard (#6878): governance policies are internal-only. Block
+  // non-internal/non-EE (customer-tier) users who hand-type /policies/new with
+  // the same audience-aware FeatureGate the agents/enforcement pages use.
+  if (!isPageVisibleForUser("policies", userOrgs, orgName)) {
+    return <FeatureGate pageId="policies" />;
+  }
 
   if (!orgName) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/policies/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/policies/page.tsx
@@ -4,11 +4,17 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { Plus, Shield, Loader2, AlertCircle } from "lucide-react";
 import { useSelectedWorkspace } from "@/hooks/useSelectedWorkspace";
+import { useAuth } from "@/contexts/AuthContext";
+import { useFeatureFlags } from "@/contexts/FeatureFlagsContext";
+import { FeatureGate } from "@/components/FeatureGate";
 import { listPolicies, activatePolicy, type Policy } from "@/lib/policy-api";
 import { PolicyCard } from "@/components/policies/PolicyCard";
 
 export default function PoliciesPage() {
   const orgName = useSelectedWorkspace();
+  const { user } = useAuth();
+  const { isPageVisibleForUser } = useFeatureFlags();
+  const userOrgs = user?.organizations ?? [];
   const [policies, setPolicies] = useState<Policy[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -55,6 +61,13 @@ export default function PoliciesPage() {
       setActivatingId(null);
     }
   };
+
+  // Route guard (#6878): governance policies are internal-only. Block
+  // non-internal/non-EE (customer-tier) users who hand-type /policies with the
+  // same audience-aware FeatureGate the agents/enforcement pages use.
+  if (!isPageVisibleForUser("policies", userOrgs, orgName)) {
+    return <FeatureGate pageId="policies" />;
+  }
 
   if (!orgName) {
     return (

--- a/apps/dashboard/src/app/(dashboard)/policies/policies-route-guard.test.tsx
+++ b/apps/dashboard/src/app/(dashboard)/policies/policies-route-guard.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Route-guard proof for the governance Policies surface (#6878).
+ *
+ * Before this fix every /policies route (the list, /new, /[policyId], and
+ * /check) had ZERO route-level guard — it only checked for a selected
+ * workspace. So a non-internal (customer-tier) user who hand-typed /policies
+ * rendered the policy manager and could create/activate/delete governance
+ * policies. The `policies` PageId is internal-only and is NOT in
+ * FALLBACK_PUBLIC_PAGES.
+ *
+ * The fix adds the canonical audience-aware guard used by the agents /
+ * enforcement / governance-playground pages:
+ *   isPageVisibleForUser('policies', userOrgs, workspace) → FeatureGate.
+ *
+ * These tests prove the guard for real, two ways:
+ *  1. Behavioral: render the actual pages (react-dom/server) with ONLY the
+ *     feature-flags context boundary mocked. Customer (resolver → false) gets
+ *     the FeatureGate deny UI and NOT the policy content; internal/EE
+ *     (resolver → true) gets the content.
+ *  2. Grounding: the customer-vs-internal premise is anchored on the REAL
+ *     audience primitives (`meetsAudience`/`resolveOrgTier`).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { meetsAudience, resolveOrgTier } from '@gal/core'
+
+const PAGE_ID = 'policies'
+const DENY_COPY = 'Governance policy management is only available to internal users'
+
+// --- Mock ONLY the boundaries the guard depends on ------------------------
+const isPageVisibleForUser = vi.fn()
+
+vi.mock('@/contexts/FeatureFlagsContext', () => ({
+  useFeatureFlags: () => ({
+    isPageVisibleForUser,
+    // Hard-wire the global flag to true so we prove the page does NOT rely on it.
+    isPageEnabled: () => true,
+    loading: false,
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { organizations: ['acme-customer'] },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/hooks/useSelectedWorkspace', () => ({
+  useSelectedWorkspace: () => 'acme-customer',
+}))
+
+// Keep dynamic-route params + data lanes inert (the guard must run first).
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ policyId: 'pol-123' }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/lib/policy-api', () => ({
+  listPolicies: vi.fn().mockResolvedValue([]),
+  activatePolicy: vi.fn(),
+  createPolicy: vi.fn(),
+  getPolicy: vi.fn().mockResolvedValue(null),
+  updatePolicy: vi.fn(),
+  deletePolicy: vi.fn(),
+}))
+
+async function renderPage(importer: () => Promise<{ default: () => unknown }>): Promise<string> {
+  const mod = await importer()
+  return renderToStaticMarkup(createElement(mod.default as () => any))
+}
+
+const PAGES: { name: string; importer: () => Promise<any>; allowMarker: string }[] = [
+  {
+    name: 'policies list',
+    importer: () => import('./page'),
+    allowMarker: 'Manage governance policies for your organization',
+  },
+  {
+    name: 'new policy',
+    importer: () => import('./new/page'),
+    allowMarker: 'Create a new governance policy for your organization',
+  },
+  {
+    name: 'policy detail',
+    importer: () => import('./[policyId]/page'),
+    // After the guard passes, the detail page renders its loading state first.
+    allowMarker: 'Loading policy...',
+  },
+  {
+    name: 'policy check',
+    importer: () => import('./check/page'),
+    allowMarker: 'Test policy enforcement decisions for tool calls',
+  },
+]
+
+describe('policies route guard (#6878)', () => {
+  beforeEach(() => {
+    isPageVisibleForUser.mockReset()
+    vi.resetModules()
+  })
+
+  for (const page of PAGES) {
+    it(`DENIES a customer-tier user on the ${page.name} page (FeatureGate, not content)`, async () => {
+      isPageVisibleForUser.mockReturnValue(false)
+      const html = await renderPage(page.importer)
+      expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+      expect(html).toContain(DENY_COPY)
+      expect(html).not.toContain(page.allowMarker)
+    })
+
+    it(`ALLOWS an internal/EE user on the ${page.name} page (content, not FeatureGate)`, async () => {
+      isPageVisibleForUser.mockReturnValue(true)
+      const html = await renderPage(page.importer)
+      expect(isPageVisibleForUser).toHaveBeenCalledWith(PAGE_ID, ['acme-customer'], 'acme-customer')
+      expect(html).toContain(page.allowMarker)
+      expect(html).not.toContain(DENY_COPY)
+    })
+  }
+
+  it('every policies page gates on the audience-aware resolver + FeatureGate', () => {
+    const files = ['page.tsx', 'new/page.tsx', '[policyId]/page.tsx', 'check/page.tsx']
+    for (const rel of files) {
+      const source = readFileSync(join(__dirname, rel), 'utf8')
+      expect(source).toContain('import { FeatureGate } from "@/components/FeatureGate"')
+      expect(source).toContain('isPageVisibleForUser("policies", userOrgs, orgName)')
+      expect(source).toContain('<FeatureGate pageId="policies" />')
+    }
+  })
+
+  it('grounding: a customer org is genuinely denied the internal "policies" tier', () => {
+    const customerTier = resolveOrgTier(null, 'free')
+    const internalTier = resolveOrgTier('internal', 'free')
+    expect(meetsAudience(customerTier, 'internal')).toBe(false)
+    expect(meetsAudience(internalTier, 'internal')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/components/FeatureGate.tsx
+++ b/apps/dashboard/src/components/FeatureGate.tsx
@@ -68,6 +68,11 @@ const PAGE_META: Partial<Record<PageId, { icon: LucideIcon; title: string; messa
     title: 'Policies Unavailable',
     message: 'Policy management is only available to internal users.',
   },
+  'policies': {
+    icon: Shield,
+    title: 'Policies Unavailable',
+    message: 'Governance policy management is only available to internal users.',
+  },
   'enforcement-audit': {
     icon: ScrollText,
     title: 'Audit Log Unavailable',


### PR DESCRIPTION
Closes #514. Adds isPageVisibleForUser + FeatureGate to 8 unguarded non-public pages (policies×4, evals×2, agents/new, compliance/sdlc); no page gates on global isPageEnabled anymore. 24 route-guard tests; full dashboard suite 390 green; tsc clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)