### PR TITLE
fix(browser-use-service): create /data for SQLite cache + align start.sh env name [ci]

### DIFF
--- a/mcp/gal-browser-use-service/Dockerfile
+++ b/mcp/gal-browser-use-service/Dockerfile
@@ -65,6 +65,11 @@ COPY main.py chrome_bridge.py ./
 # Placeholder for the GAL Chrome extension (mounted or copied at build time)
 RUN mkdir -p /app/gal-extension
 
+# Create the dir for BROWSER_USE_DB (set to /data/... above) so the SQLite cache is
+# writable; declare it a volume for persistence across container restarts.
+RUN mkdir -p /data
+VOLUME ["/data"]
+
 EXPOSE 8123
 
 # Bind to localhost by default; override HOST/PORT (e.g. HOST=0.0.0.0) to expose.

--- a/mcp/gal-browser-use-service/start.sh
+++ b/mcp/gal-browser-use-service/start.sh
@@ -12,8 +12,8 @@ source .venv/bin/activate
 pip install -q -r requirements.txt
 
 export PYTHONPATH="${PYTHONPATH:-}:$(pwd)"
-export GAL_BROWSER_USE_DB="${GAL_BROWSER_USE_DB:-/tmp/gal-browser-use-cache.db}"
-export GAL_BROWSER_USE_LLM="${GAL_BROWSER_USE_LLM:-gpt-4o}"
-export GAL_BROWSER_USE_MAX_STEPS="${GAL_BROWSER_USE_MAX_STEPS:-50}"
+# main.py reads BROWSER_USE_DB (not GAL_BROWSER_USE_DB); the LLM model and max_steps are
+# per-request body fields, not env vars — so only the DB path is settable here.
+export BROWSER_USE_DB="${BROWSER_USE_DB:-/tmp/gal-browser-use-cache.db}"
 
 exec uvicorn main:app --host 127.0.0.1 --port 8123 --reload


### PR DESCRIPTION
## What
Two non-blocking follow-ups from the **#472** adversarial review (browser-use service):

1. **Dockerfile** — `BROWSER_USE_DB=/data/browser_use_cache.db` was set but `/data` was never created (only `/app/gal-extension`), so the SQLite cache write failed in that image. Added `RUN mkdir -p /data` + `VOLUME ["/data"]`.
2. **start.sh** — exported `GAL_BROWSER_USE_DB/LLM/MAX_STEPS`, but `main.py` reads `BROWSER_USE_DB` and takes model + max_steps from the request body, so all three were dead. Now exports the real `BROWSER_USE_DB` name and drops the two no-op exports.

## Verify
- `bash -n start.sh` OK; exported `BROWSER_USE_DB` matches `main.py`'s `os.getenv("BROWSER_USE_DB")`; no live `GAL_BROWSER_USE_*` export remains.
- `python -m py_compile main.py` OK.

## Scope
2 files in `mcp/gal-browser-use-service` — not a deploy-gated package. Reversible.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)