### PR TITLE
fix(dashboard): playground toolbar wraps so Clear isn't clipped [ci]

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/governance/playground/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/governance/playground/page.tsx
@@ -252,14 +252,14 @@ export default function GovernancePlaygroundPage() {
     <div className="flex flex-col h-full max-h-[calc(100vh-4rem)]">
       {/* Header */}
       <div
-        className="flex items-center justify-between px-6 py-4 flex-shrink-0"
+        className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-6 py-4 flex-shrink-0"
         style={{ borderBottom: '1px solid var(--border-subtle)' }}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 items-center gap-3">
           <GalAvatar size="lg" />
-          <div>
+          <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h1 className="text-xl font-semibold text-[var(--text-primary)]">Ask GAL</h1>
+              <h1 className="text-xl font-semibold text-[var(--text-primary)] truncate">Ask GAL</h1>
               <span
                 className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium"
                 style={{
@@ -277,7 +277,7 @@ export default function GovernancePlaygroundPage() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <div
             className="flex items-center gap-1 p-1 rounded-xl"
             style={{


### PR DESCRIPTION
## Problem

`/governance/playground` header was a single non-wrapping flex row: title group on the left, toolbar (model selector + System Prompt + Clear) on the right. On narrow viewports the right toolbar got pushed past the visible area and the **Clear button was clipped** (#506).

## Fix (CSS-only, surgical)

In `apps/dashboard/src/app/(dashboard)/governance/playground/page.tsx`:

- **Header row**: `flex` → `flex flex-wrap … gap-x-4 gap-y-2` — the toolbar wraps below the title when there isn't room on one line.
- **Left title group**: added `min-w-0` (group + inner div) and `truncate` on the `<h1>` — the title yields space instead of forcing the toolbar off-screen.
- **Right toolbar group**: `flex items-center gap-2` → `flex flex-wrap items-center justify-end gap-2` — its own children (model selector, System Prompt, Clear) wrap and stay right-aligned rather than overflowing the (sidebar-reduced) content area.

No logic, behavior, or non-CSS changes. Wide layout is unchanged.

## Verification achieved

**Build / type / tests (in worktree, deps installed):**
- `npx tsc --noEmit` → clean (exit 0)
- `vitest run` for the playground route-guard suite → **4/4 passed**
- (`next lint` could not load `next/core-web-vitals` — `eslint-config-next` is referenced by `.eslintrc.json` but is not a declared/installed dependency; this is a pre-existing repo config gap, unrelated to this diff, and the diff is className-only so tsc fully validates it.)

**Visual — rendered in a real browser** (Next dev + demo mode; the page is internal/EE-gated, unlocked locally via `NEXT_PUBLIC_DEMO_MODE` + a format-only dummy EE key in a gitignored `.env.local`, since EE-gate runs *before* the demo bypass in `isPageVisibleForUser`). Measured the Clear button's bounding box vs. the viewport and checked for horizontal overflow:

| Viewport | Clear fully visible | Horizontal overflow | Layout |
|---|---|---|---|
| 1280px (wide) | ✅ yes (right=1256 ≤ 1280) | none | single row, title left / toolbar right — **unchanged** |
| 768px | ✅ yes | none | toolbar wraps below title |
| 640px | ✅ yes (right=616 ≤ 640) | none | toolbar wraps; model selector + buttons wrap within group |

Before the toolbar-group `flex-wrap`, the toolbar block wrapped but its *internal* row (457px) still overflowed the ~400px content area and clipped Clear; after, no clip at any tested width.

Closes #506