### PR TITLE
fix(dashboard): graceful demo-mode state for background-agents/approved-config/evals [ci]

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/approved-config/ApprovedConfigClient.tsx
+++ b/apps/dashboard/src/app/(dashboard)/approved-config/ApprovedConfigClient.tsx
@@ -17,7 +17,7 @@ import { useSelectedWorkspace } from '@/hooks/useSelectedWorkspace'
 import { getUserFriendlyError } from '@/lib/errors'
 import { loadApprovalHandoff, clearApprovalHandoff, isStageableSelection } from '@/lib/approvalHandoff'
 import { isDemoMode } from '@/lib/demo-guard'
-import { DEMO_ORGANIZATION, DEMO_GITHUB_STATUS, DEMO_APPROVED_CONFIG_RESPONSE } from '@/lib/demo-data'
+import { DEMO_ORGANIZATION, DEMO_GITHUB_STATUS, DEMO_APPROVED_CONFIG_RESPONSE, DEMO_CONFIG_POLICIES } from '@/lib/demo-data'
 import { appendConfigToBundleTyped } from './approved-config-bundle'
 import { OrphanBanner } from '@/components/approved-config/OrphanBanner'
 // PlatformSelector removed - GAL uses unified configs (#1339)
@@ -337,6 +337,16 @@ function ApprovedConfig() {
   useEffect(() => {
     if (!orgName) return
     setPoliciesLoading(true)
+    // Demo mode: serve pre-seeded policies so the selector resolves instead of
+    // spinning on "Loading policies..." forever — the API is unavailable on the
+    // public live demo (#507).
+    if (isDemoMode()) {
+      setPolicies(DEMO_CONFIG_POLICIES)
+      const active = DEMO_CONFIG_POLICIES.find(pol => pol.isActive)
+      if (active) setSelectedPolicyId(active.id)
+      setPoliciesLoading(false)
+      return
+    }
     api.listPolicies(orgName).then(({ policies: p }) => {
       setPolicies(p)
       const active = p.find(pol => pol.isActive)

--- a/apps/dashboard/src/app/(dashboard)/background-agents/background-agents-route-contract.test.ts
+++ b/apps/dashboard/src/app/(dashboard)/background-agents/background-agents-route-contract.test.ts
@@ -14,7 +14,11 @@ const backgroundAgentSessionPageSource = readFileSync(
 
 describe('background-agents legacy route contract', () => {
   it('redirects the legacy background-agents list route to the unified sessions page (#6107)', () => {
-    expect(backgroundAgentsPageSource).toContain("redirect('/sessions')")
+    // Client-side redirect (#507): a server `redirect()` thrown inside the
+    // force-dynamic client `(dashboard)` layout surfaces as a blank client-side
+    // exception on the public demo, so the list route navigates via the router.
+    expect(backgroundAgentsPageSource).toContain("'use client'")
+    expect(backgroundAgentsPageSource).toContain("router.replace('/sessions')")
   })
 
   it('redirects legacy background-agents session detail routes to the unified session detail page (#6107)', () => {

--- a/apps/dashboard/src/app/(dashboard)/background-agents/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/background-agents/page.tsx
@@ -1,5 +1,30 @@
-import { redirect } from 'next/navigation'
+'use client'
 
-export default async function BackgroundAgentsRedirectPage() {
-  redirect('/sessions')
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+
+/**
+ * Legacy /background-agents list route → unified /sessions page (#6107).
+ *
+ * Redirect is done client-side via useRouter().replace rather than the server
+ * `redirect()` helper: this route is rendered inside the force-dynamic, client
+ * `(dashboard)` layout, where a server-thrown NEXT_REDIRECT surfaces to the
+ * browser as an unhandled client-side exception (blank "Application error"
+ * page) instead of a clean navigation — which is exactly what demo visitors
+ * hit on the public live demo (#507). Replacing keeps the legacy URL out of
+ * history and lands the visitor on /sessions with a brief, neutral spinner.
+ */
+export default function BackgroundAgentsRedirectPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.replace('/sessions')
+  }, [router])
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <Loader2 className="w-6 h-6 animate-spin" style={{ color: 'var(--text-tertiary)' }} />
+    </div>
+  )
 }

--- a/apps/dashboard/src/app/(dashboard)/evals/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/evals/page.tsx
@@ -21,7 +21,7 @@ import { FeatureGate } from "@/components/FeatureGate";
 import { listEvalSuites, runEval } from "@/lib/eval-api";
 import type { EvalSuiteSummary } from "@/lib/eval-api";
 import { isDemoMode } from "@/lib/demo-guard";
-import { DEMO_ORG } from "@/lib/demo-data";
+import { DEMO_ORG, DEMO_EVAL_SUITES } from "@/lib/demo-data";
 
 function formatPercent(value: number): string {
   return `${(value * 100).toFixed(0)}%`;
@@ -68,6 +68,12 @@ export default function EvalsPage() {
     setLoading(true);
     setError(null);
     try {
+      // Demo mode: serve pre-seeded suites without hitting the real API, which
+      // is unavailable on the public live demo (#507).
+      if (isDemoMode()) {
+        setSuites(DEMO_EVAL_SUITES);
+        return;
+      }
       if (!orgName) {
         setSuites([]);
         return;

--- a/apps/dashboard/src/lib/demo-data.ts
+++ b/apps/dashboard/src/lib/demo-data.ts
@@ -40,9 +40,11 @@ import type {
   SecurityStandardItem,
   ToolPolicyItem,
   DeveloperStatusSummary,
+  ConfigPolicyItem,
 } from '@/lib/api'
 import type { Session } from '@gal/types'
 import type { ConfigProposal } from '@gal/types'
+import type { EvalSuiteSummary } from '@/lib/eval-api'
 
 export const DEMO_ORG = 'acme-corp'
 
@@ -1659,5 +1661,99 @@ export const DEMO_TOOL_POLICIES: ToolPolicyItem[] = [
     createdAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
     updatedAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
     enabled: true,
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Demo eval suites (matches EvalSuiteSummary from @/lib/eval-api)
+// Served on /evals in demo mode so the page renders real-looking suites
+// instead of a "Failed to fetch eval suites" error.
+// ---------------------------------------------------------------------------
+export const DEMO_EVAL_SUITES: EvalSuiteSummary[] = [
+  {
+    id: 'suite-pr-review',
+    name: 'PR Review Agent',
+    description: 'Validates that the PR-review agent flags security issues and suggests fixes',
+    subject: { kind: 'agent', agentId: 'pr-review-agent' },
+    evaluatorId: 'llm-judge-v2',
+    caseCount: 24,
+    latestReport: {
+      suiteId: 'suite-pr-review',
+      score: 0.92,
+      passed: true,
+      generatedAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
+      metrics: [
+        { metric: 'precision', score: 0.94, correct: 23, total: 24, passed: true },
+        { metric: 'recall', score: 0.88, correct: 21, total: 24, passed: true },
+        { metric: 'fix-quality', score: 0.95, correct: 23, total: 24, passed: true },
+      ],
+    },
+  },
+  {
+    id: 'suite-triage',
+    name: 'Issue Triage Agent',
+    description: 'Checks label accuracy and priority assignment on incoming issues',
+    subject: { kind: 'taskType', taskType: 'issue-triage' },
+    evaluatorId: 'llm-judge-v2',
+    caseCount: 40,
+    latestReport: {
+      suiteId: 'suite-triage',
+      score: 0.78,
+      passed: true,
+      generatedAt: new Date(Date.now() - 30 * 60 * 60 * 1000).toISOString(),
+      metrics: [
+        { metric: 'label-accuracy', score: 0.82, correct: 33, total: 40, passed: true },
+        { metric: 'priority-match', score: 0.74, correct: 30, total: 40, passed: true },
+      ],
+    },
+  },
+  {
+    id: 'suite-codegen',
+    name: 'Code Generation Agent',
+    description: 'Compile + test pass rate for generated patches against held-out tasks',
+    subject: { kind: 'agent', agentId: 'codegen-agent' },
+    evaluatorId: 'exec-harness-v1',
+    caseCount: 18,
+    latestReport: {
+      suiteId: 'suite-codegen',
+      score: 0.61,
+      passed: false,
+      generatedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      metrics: [
+        { metric: 'compiles', score: 0.83, correct: 15, total: 18, passed: true },
+        { metric: 'tests-pass', score: 0.5, correct: 9, total: 18, passed: false },
+        { metric: 'no-regressions', score: 0.5, correct: 9, total: 18, passed: false },
+      ],
+    },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Demo config policies (matches ConfigPolicyItem from @/lib/api)
+// Served on /approved-config in demo mode so the policy selector resolves
+// instead of spinning on "Loading policies..." forever (#507).
+// ---------------------------------------------------------------------------
+export const DEMO_CONFIG_POLICIES: ConfigPolicyItem[] = [
+  {
+    id: 'policy-security-baseline',
+    name: 'security-baseline',
+    description: 'Org-wide approved AI agent configuration for acme-corp',
+    isBuiltin: false,
+    isActive: true,
+    createdAt: '2026-02-01T10:00:00Z',
+    updatedAt: '2026-03-08T11:00:00Z',
+    createdBy: 'sarah.chen',
+    config: DEMO_APPROVED_CONFIG_RESPONSE as unknown as Record<string, unknown>,
+  },
+  {
+    id: 'policy-strict-prod',
+    name: 'strict-prod',
+    description: 'Tighter policy for production repositories — block mode, no external network',
+    isBuiltin: false,
+    isActive: false,
+    createdAt: '2026-02-20T09:00:00Z',
+    updatedAt: '2026-02-20T09:00:00Z',
+    createdBy: 'alex.kim',
+    config: {},
   },
 ]


### PR DESCRIPTION
## Problem

With `NEXT_PUBLIC_DEMO_MODE=true` (the public live demo advertised on app.gal.run, EE-license-key build so the demo bypass is reached), three dashboard sections degraded into broken-looking pages because their data sources are unavailable and there was no demo fallback:

- **`/background-agents`** — main content area entirely **blank** ("Application error: a client-side exception has occurred").
- **`/approved-config`** — stuck on a **loading skeleton forever** ("Loading policies...").
- **`/evals`** — **"Failed to fetch eval suites"**, stats read 0.

## Fix

Reused the **existing demo-fixture pattern** that `/enforcement` and `/audit-logs` already use — an `isDemoMode()` branch that serves pre-seeded data from `apps/dashboard/src/lib/demo-data.ts` instead of hitting the unavailable API (e.g. `DEMO_AUDIT_LOG_ENTRIES`, `DEMO_BILLING_STATUS`). No new bespoke design.

- **`/approved-config`** — root cause was the policy-selector `useEffect` calling `api.listPolicies()`, which never resolves on the demo, leaving `policiesLoading` stuck (the *main* config bundle already had a demo branch; the policy selector did not). Added an `isDemoMode()` branch serving new `DEMO_CONFIG_POLICIES` (`ConfigPolicyItem[]`), mirroring the existing main-config demo branch in the same file.
- **`/evals`** — `loadSuites()` hit the real API. Added an `isDemoMode()` branch serving new `DEMO_EVAL_SUITES` (`EvalSuiteSummary[]`); the existing `finally { setLoading(false) }` resolves the skeleton.
- **`/background-agents`** — different root cause (not data): the legacy redirect page used the **server `redirect()`** helper, but this route renders inside the **force-dynamic, client `(dashboard)` layout**, where a server-thrown `NEXT_REDIRECT` surfaces to the browser as an unhandled **client-side exception** (the blank "Application error") instead of a clean navigation. (`/onboarding` and `/agents/[sessionId]` share this latent bug — see note below.) Converted to a **client redirect** (`'use client'` + `useRouter().replace('/sessions')`) with a neutral spinner, matching the existing client-redirect idiom (`HomeContent.tsx`). The `/sessions` target already renders demo sessions correctly. Updated the route-contract test accordingly.

New demo fixtures in `demo-data.ts` are typed against `EvalSuiteSummary` (`@/lib/eval-api`) and `ConfigPolicyItem` (`@/lib/api`) — `tsc --noEmit` confirms shape conformance.

## Verification (rendered in demo mode, EE key in a gitignored `.env.local`, removed after)

| Route | Verification | Result |
|---|---|---|
| `/evals` | **rendered-clean (screenshot)** | Suites 3 / Passing 2/3 / Avg 77% + 3 demo suites with metric bars. No error, no zero-stats. |
| `/approved-config` | **rendered-clean (screenshot)** | Policy selector resolves (`security-baseline` Active + `strict-prod`); config bundle populated (AGENTS.md, Commands 3, Hooks 2…). No infinite skeleton. |
| `/background-agents` | **rendered-clean (screenshot)** | Cleanly redirects to a fully-populated `/sessions` Background tab (demo session, provider pool). No blank "Application error". |

- `npx tsc --noEmit` — clean (exit 0).
- `npx vitest run` (full dashboard) — **390 tests / 99 files passed**, including the updated `background-agents-route-contract` and the `evals` / `approved-config` guard tests.
- No secret entered the diff: the dummy **format-only** EE key (`gal-ee-…`, no crypto, no real value) stayed in a gitignored `apps/dashboard/.env.local` and was removed after verification. Diff is 5 files only.

## Note (out of scope, follow-up)

The same client-side-exception bug affects the other server-`redirect()` pages under `(dashboard)` (`/onboarding`, `/agents/[sessionId]`, `/background-agents/[sessionId]`). This PR fixes only the `/background-agents` route named in #507; a follow-up should apply the same client-redirect to the siblings.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)