### PR TITLE
honesty sweep: remove fabricated reviews + false compliance claims + nonexistent-command pointers

### DIFF
--- a/apps/website/app/compliance/page.tsx
+++ b/apps/website/app/compliance/page.tsx
@@ -450,7 +450,7 @@ function CTASection() {
     <section className="py-20 px-8">
       <div className="max-w-[1376px] mx-auto text-center">
         <h2 className="text-3xl md:text-4xl font-medium tracking-tight text-black mb-6">
-          Achieve AI compliance today
+          Build toward AI compliance today
         </h2>
         
         <p className="text-lg text-black/60 mb-8 max-w-xl mx-auto">


### PR DESCRIPTION
## Summary

Honesty/legal-risk sweep of the public OSS repo + gal.run website covering three classes of false PUBLIC claims:

1. **Fabricated reviews/ratings** (JSON-LD `aggregateRating` / `ratingValue` / `reviewCount`)
2. **False compliance claims** (GAL *is* SOC 2 / ISO 27001 / HIPAA compliant / certified / "Ready")
3. **Nonexistent-command pointers** (telling users to run `gal enforce install`)

## Key finding: the bulk was already remediated by #484

Commit `ef107fe` ("docs/site honesty + positioning pass (coding-agent enforcement)", #484, merged 2026-06-22) already removed the fabricated `aggregateRating` structured data, reframed compliance as "building toward / maps to" with explicit non-certification disclaimers, and labeled the unshipped `gal enforce install` / `gal sync` commands as "(coming in v1.0)". A full re-audit against current `main` confirms those fixes are in place.

This PR fixes the **one residual overclaim** that survived that pass.

## Files changed

- `apps/website/app/compliance/page.tsx` — CTA header `Achieve AI compliance today` → `Build toward AI compliance today`. The old phrasing implied GAL alone makes the user compliant, contradicting the rest of the (already-honest) page, which consistently says GAL helps you *build toward / map to* frameworks and that "GAL itself does not hold a SOC 2 certification."

## Audit results per class (current `main`)

**Class 1 — fabricated reviews/ratings:** None remain on the website. No `aggregateRating` / `ratingValue` / `reviewCount` / `@type: Review` structured-data blocks in `apps/website`. (The `reviewCount` symbol in `packages/gal-code/.../session*.tsx` is an unrelated UI signal counting files under code review — not a star rating.)

**Class 2 — false compliance:** No "SOC 2 compliant", "SOC 2 / ISO 27001 Ready", "HIPAA-ready", "certified", or NIST-as-certification assertions. All SOC 2 / ISO 27001 / HIPAA mentions across `compliance`, `features/security`, `features/observability`, `governance`, the integration pages, and blog articles use honest framing ("build toward", "map to", "demonstrate to auditors", "evidence for"), and three pages carry an explicit "GAL itself does not hold a SOC 2 / ISO 27001 certification" disclaimer.

**Class 3 — nonexistent commands:** Both `gal enforce install` references in the dashboard (`enforcement/page.tsx`, `enforcement/compliance/page.tsx`) are already labeled "(coming in v1.0)" and rendered with an "Upcoming" status — not live run-this instructions.

## Build

`npm run build --workspace=apps/website` passes — Next.js 14, 19/19 pages generated (including `/compliance`), types valid.

## Scope notes

PR-only. No merge, no deploy (production deploy is a founder hard-gate). `package-lock.json` churn from a local `npm install` (npm 11 vs committed npm 10 lockfile) was intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)