### PR TITLE
feat(computer-use): add Windows (win32) desktop actuation

### DIFF
--- a/mcp/computer-use/src/tools.ts
+++ b/mcp/computer-use/src/tools.ts
@@ -2,6 +2,10 @@ import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { resolve } from "path";
 import os from "os";
+import {
+  winScreenshot, winClick, winType, winKey, winMouseMove, winScroll, winDrag,
+  winScreenSize, winMousePosition,
+} from "./win.js";
 
 const log = (msg: string) =>
   process.stderr.write(`[gal-computer-use] ${msg}\n`);
@@ -22,6 +26,12 @@ export function screenshot(path?: string): string {
     } catch {
       execSync(`scrot ${out}`);
     }
+    return out;
+  }
+
+  if (platform === "win32") {
+    winScreenshot(out);
+    log(`Screenshot saved: ${out}`);
     return out;
   }
 
@@ -62,6 +72,11 @@ export function click(x: number, y: number): string {
     return `Clicked at (${x}, ${y})`;
   }
 
+  if (platform === "win32") {
+    winClick(x, y, "left");
+    return `Clicked at (${x}, ${y})`;
+  }
+
   throw new Error(`Click not supported on ${platform}`);
 }
 
@@ -80,6 +95,11 @@ export function typeText(text: string): string {
     return `Typed: ${text}`;
   }
 
+  if (platform === "win32") {
+    winType(text);
+    return `Typed: ${text}`;
+  }
+
   throw new Error(`Type not supported on ${platform}`);
 }
 
@@ -95,6 +115,11 @@ export function keyPress(key: string): string {
 
   if (platform === "linux") {
     execSync(`xdotool key ${key}`);
+    return `Pressed: ${key}`;
+  }
+
+  if (platform === "win32") {
+    winKey(key);
     return `Pressed: ${key}`;
   }
 
@@ -120,6 +145,11 @@ export function rightClick(x: number, y: number): string {
     return `Right-clicked at (${x}, ${y})`;
   }
 
+  if (platform === "win32") {
+    winClick(x, y, "right");
+    return `Right-clicked at (${x}, ${y})`;
+  }
+
   throw new Error(`Right click not supported on ${platform}`);
 }
 
@@ -139,6 +169,11 @@ export function doubleClick(x: number, y: number): string {
 
   if (platform === "linux") {
     execSync(`xdotool mousemove ${x} ${y} click --repeat 2 1`);
+    return `Double-clicked at (${x}, ${y})`;
+  }
+
+  if (platform === "win32") {
+    winClick(x, y, "left", true);
     return `Double-clicked at (${x}, ${y})`;
   }
 
@@ -311,6 +346,11 @@ export function mouseMove(x: number, y: number): string {
     return `Mouse moved to (${x}, ${y})`;
   }
 
+  if (platform === "win32") {
+    winMouseMove(x, y);
+    return `Mouse moved to (${x}, ${y})`;
+  }
+
   throw new Error(`Mouse move not supported on ${platform}`);
 }
 
@@ -343,6 +383,11 @@ export function scroll(
     return `Scrolled ${direction} ${amount}`;
   }
 
+  if (platform === "win32") {
+    winScroll(amount, direction);
+    return `Scrolled ${direction} ${Math.abs(amount)}`;
+  }
+
   throw new Error(`Scroll not supported on ${platform}`);
 }
 
@@ -368,6 +413,11 @@ export function drag(x1: number, y1: number, x2: number, y2: number): string {
     execSync(
       `xdotool mousemove ${x1} ${y1} mousedown 1 mousemove ${x2} ${y2} mouseup 1`,
     );
+    return `Dragged from (${x1},${y1}) to (${x2},${y2})`;
+  }
+
+  if (platform === "win32") {
+    winDrag(x1, y1, x2, y2);
     return `Dragged from (${x1},${y1}) to (${x2},${y2})`;
   }
 
@@ -430,6 +480,10 @@ export function getScreenSize(): { width: number; height: number } {
     return { width, height };
   }
 
+  if (platform === "win32") {
+    return winScreenSize();
+  }
+
   return { width: 1920, height: 1080 };
 }
 
@@ -463,6 +517,10 @@ export function getMousePosition(): { x: number; y: number } {
     const x = parseInt(result.match(/x:(\d+)/)?.[1] || "0");
     const y = parseInt(result.match(/y:(\d+)/)?.[1] || "0");
     return { x, y };
+  }
+
+  if (platform === "win32") {
+    return winMousePosition();
   }
 
   return { x: 0, y: 0 };

--- a/mcp/computer-use/src/win.ts
+++ b/mcp/computer-use/src/win.ts
@@ -1,0 +1,124 @@
+// Windows (win32) desktop actuation for the gal-computer-use MCP.
+//
+// macOS uses screencapture/cliclick/osascript and Linux uses scrot/xdotool; Windows has no equivalent
+// CLI, so these shell out to PowerShell + .NET (System.Drawing / System.Windows.Forms / user32 P/Invoke),
+// which are present on Windows 10/11 including Windows-on-ARM. Each helper writes a short .ps1 to a temp
+// file and runs it (avoids the quoting hell of inline -Command), returning stdout.
+import { execFileSync } from "child_process";
+import { writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Run a PowerShell script. The script is written to a temp .ps1 and executed via execFileSync with an
+// ARGUMENT ARRAY (no shell) — so nothing is interpolated into a shell command line. Any caller-supplied
+// text/key that reaches the script body is placed inside PowerShell single-quoted strings with '' escaping
+// (see winType/winKey), so it cannot break out of the string literal either.
+function runPs(script: string): string {
+  const file = join(tmpdir(), `gal-cu-${Date.now()}-${Math.random().toString(36).slice(2)}.ps1`);
+  writeFileSync(file, script, "utf8");
+  try {
+    return execFileSync(
+      "powershell",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", file],
+      { encoding: "utf8", windowsHide: true },
+    ).trim();
+  } finally {
+    try {
+      rmSync(file, { force: true });
+    } catch {
+      /* best-effort temp cleanup */
+    }
+  }
+}
+
+const MOUSE_PINVOKE = `
+Add-Type -Name M -Namespace GalCU -MemberDefinition @'
+[DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+[DllImport("user32.dll")] public static extern void mouse_event(uint flags, uint dx, uint dy, uint data, int extra);
+[DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
+public struct POINT { public int X; public int Y; }
+'@
+`;
+// mouse_event flags
+const LEFTDOWN = "0x0002", LEFTUP = "0x0004", RIGHTDOWN = "0x0008", RIGHTUP = "0x0010", WHEEL = "0x0800";
+
+export function winScreenshot(out: string): void {
+  runPs(`
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+$b = [System.Windows.Forms.SystemInformation]::VirtualScreen
+$bmp = New-Object System.Drawing.Bitmap $b.Width, $b.Height
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($b.Location, [System.Drawing.Point]::Empty, $b.Size)
+$bmp.Save('${out.replace(/'/g, "''")}', [System.Drawing.Imaging.ImageFormat]::Png)
+$g.Dispose(); $bmp.Dispose()
+`);
+}
+
+export function winMouseMove(x: number, y: number): void {
+  runPs(`${MOUSE_PINVOKE}[GalCU.M]::SetCursorPos(${x | 0}, ${y | 0})`);
+}
+
+export function winClick(x: number, y: number, button: "left" | "right" = "left", double = false): void {
+  const [down, up] = button === "right" ? [RIGHTDOWN, RIGHTUP] : [LEFTDOWN, LEFTUP];
+  const once = `[GalCU.M]::mouse_event(${down},0,0,0,0); [GalCU.M]::mouse_event(${up},0,0,0,0)`;
+  runPs(`${MOUSE_PINVOKE}[GalCU.M]::SetCursorPos(${x | 0}, ${y | 0})\n${once}${double ? "\nStart-Sleep -Milliseconds 50\n" + once : ""}`);
+}
+
+export function winScroll(amount: number, direction: "up" | "down"): void {
+  const delta = direction === "down" ? -120 * Math.abs(amount) : 120 * Math.abs(amount);
+  runPs(`${MOUSE_PINVOKE}[GalCU.M]::mouse_event(${WHEEL},0,0,${delta},0)`);
+}
+
+export function winDrag(x1: number, y1: number, x2: number, y2: number): void {
+  runPs(`${MOUSE_PINVOKE}
+[GalCU.M]::SetCursorPos(${x1 | 0}, ${y1 | 0})
+[GalCU.M]::mouse_event(${LEFTDOWN},0,0,0,0)
+Start-Sleep -Milliseconds 80
+[GalCU.M]::SetCursorPos(${x2 | 0}, ${y2 | 0})
+[GalCU.M]::mouse_event(${LEFTUP},0,0,0,0)
+`);
+}
+
+// SendKeys metacharacters must be brace-escaped so literal text types verbatim. Exported for tests.
+export function escapeSendKeys(text: string): string {
+  return text.replace(/[+^%~(){}\[\]]/g, (c) => `{${c}}`);
+}
+
+export function winType(text: string): void {
+  runPs(`Add-Type -AssemblyName System.Windows.Forms
+[System.Windows.Forms.SendKeys]::SendWait('${escapeSendKeys(text).replace(/'/g, "''")}')`);
+}
+
+// Map common key names to SendKeys tokens; pass single chars through.
+const KEY_MAP: Record<string, string> = {
+  Return: "{ENTER}", Enter: "{ENTER}", Tab: "{TAB}", Escape: "{ESC}", Esc: "{ESC}",
+  BackSpace: "{BACKSPACE}", Delete: "{DELETE}", Up: "{UP}", Down: "{DOWN}", Left: "{LEFT}", Right: "{RIGHT}",
+  Home: "{HOME}", End: "{END}", space: " ",
+};
+
+// Resolve a key name to its SendKeys token. Exported for tests.
+export function sendKeysToken(key: string): string {
+  return KEY_MAP[key] ?? (key.length === 1 ? escapeSendKeys(key) : `{${key.toUpperCase()}}`);
+}
+
+export function winKey(key: string): void {
+  const token = sendKeysToken(key);
+  runPs(`Add-Type -AssemblyName System.Windows.Forms
+[System.Windows.Forms.SendKeys]::SendWait('${token.replace(/'/g, "''")}')`);
+}
+
+export function winScreenSize(): { width: number; height: number } {
+  const out = runPs(`Add-Type -AssemblyName System.Windows.Forms
+$b = [System.Windows.Forms.SystemInformation]::VirtualScreen
+"$($b.Width) $($b.Height)"`);
+  const [width, height] = out.split(/\s+/).map(Number);
+  return { width: width || 1920, height: height || 1080 };
+}
+
+export function winMousePosition(): { x: number; y: number } {
+  const out = runPs(`Add-Type -AssemblyName System.Windows.Forms
+$p = [System.Windows.Forms.Cursor]::Position
+"$($p.X) $($p.Y)"`);
+  const [x, y] = out.split(/\s+/).map(Number);
+  return { x: x || 0, y: y || 0 };
+}

--- a/mcp/computer-use/src/win.ts
+++ b/mcp/computer-use/src/win.ts
@@ -34,7 +34,7 @@ function runPs(script: string): string {
 const MOUSE_PINVOKE = `
 Add-Type -Name M -Namespace GalCU -MemberDefinition @'
 [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
-[DllImport("user32.dll")] public static extern void mouse_event(uint flags, uint dx, uint dy, uint data, int extra);
+[DllImport("user32.dll")] public static extern void mouse_event(uint flags, uint dx, uint dy, int data, int extra);
 [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT p);
 public struct POINT { public int X; public int Y; }
 '@
@@ -96,9 +96,12 @@ const KEY_MAP: Record<string, string> = {
   Home: "{HOME}", End: "{END}", space: " ",
 };
 
-// Resolve a key name to its SendKeys token. Exported for tests.
+// Resolve a key name to its SendKeys token. Exported for tests. An unknown multi-char key is wrapped as
+// {NAME}; strip braces from it first so a stray "}" can't malform the SendKeys token.
 export function sendKeysToken(key: string): string {
-  return KEY_MAP[key] ?? (key.length === 1 ? escapeSendKeys(key) : `{${key.toUpperCase()}}`);
+  if (KEY_MAP[key]) return KEY_MAP[key];
+  if (key.length === 1) return escapeSendKeys(key);
+  return `{${key.toUpperCase().replace(/[{}]/g, "")}}`;
 }
 
 export function winKey(key: string): void {

--- a/mcp/computer-use/test/win.test.ts
+++ b/mcp/computer-use/test/win.test.ts
@@ -1,0 +1,38 @@
+// Unit tests for the Windows (win32) actuation pure logic — the SendKeys escaping + key mapping.
+// The actuation itself needs a Windows desktop (validated on real Windows: screen-size, mouse-position,
+// SetCursorPos, mouse_event click, SendKeys all work; screenshot needs an interactive session). These
+// tests cover the cross-platform-runnable string logic.
+//
+// Run locally:  node --test --experimental-strip-types test/win.test.ts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { escapeSendKeys, sendKeysToken } from "../src/win.ts";
+
+describe("escapeSendKeys", () => {
+  it("brace-escapes SendKeys metacharacters so they type literally", () => {
+    assert.equal(escapeSendKeys("a+b^c%d~e"), "a{+}b{^}c{%}d{~}e");
+    assert.equal(escapeSendKeys("(x)[y]{z}"), "{(}x{)}{[}y{]}{{}z{}}");
+  });
+  it("leaves ordinary text untouched", () => {
+    assert.equal(escapeSendKeys("SIM-FINAL-001"), "SIM-FINAL-001");
+    assert.equal(escapeSendKeys("hello world 42"), "hello world 42");
+  });
+});
+
+describe("sendKeysToken", () => {
+  it("maps named keys to SendKeys tokens", () => {
+    assert.equal(sendKeysToken("Return"), "{ENTER}");
+    assert.equal(sendKeysToken("Enter"), "{ENTER}");
+    assert.equal(sendKeysToken("Tab"), "{TAB}");
+    assert.equal(sendKeysToken("Escape"), "{ESC}");
+    assert.equal(sendKeysToken("Up"), "{UP}");
+  });
+  it("passes a single char through (escaped)", () => {
+    assert.equal(sendKeysToken("a"), "a");
+    assert.equal(sendKeysToken("+"), "{+}");
+  });
+  it("wraps an unknown multi-char key as a token", () => {
+    assert.equal(sendKeysToken("F5"), "{F5}");
+    assert.equal(sendKeysToken("pgdn"), "{PGDN}");
+  });
+});

--- a/mcp/computer-use/test/win.test.ts
+++ b/mcp/computer-use/test/win.test.ts
@@ -35,4 +35,7 @@ describe("sendKeysToken", () => {
     assert.equal(sendKeysToken("F5"), "{F5}");
     assert.equal(sendKeysToken("pgdn"), "{PGDN}");
   });
+  it("strips stray braces from an unknown key so the token can't be malformed", () => {
+    assert.equal(sendKeysToken("fo}o"), "{FOO}");
+  });
 });


### PR DESCRIPTION
## Add Windows (win32) desktop actuation to the computer-use MCP

The MCP supported **macOS + Linux** only (`os.platform()` branches that `throw` on `win32`). This adds **Windows** so agents can drive a Windows desktop — including **Windows-on-ARM**, where PowerShell + .NET ship in-box. No new dependencies: it shells out to PowerShell + .NET (`System.Drawing` / `System.Windows.Forms` / `user32` P/Invoke).

### What
- **`src/win.ts`** — `winScreenshot` (System.Drawing `CopyFromScreen`), `winClick`/`rightClick`/`doubleClick` + `winMouseMove` (`SetCursorPos` + `mouse_event`), `winType` + `winKey` (`SendKeys`, with metacharacter escaping + a key-name map), `winScroll` (`mouse_event` WHEEL), `winDrag`, `winScreenSize`/`winMousePosition`.
- **`tools.ts`** — `win32` branches added to screenshot / click / typeText / keyPress / rightClick / doubleClick / mouseMove / scroll / drag / getScreenSize / getMousePosition.

### Safety
`runPs()` writes the script to a temp `.ps1` and runs it via **`execFileSync` with an argument array** (no shell — nothing is interpolated into a command line). Any caller-supplied text/keys are placed inside PowerShell **single-quoted strings with `''` escaping** (no breakout).

### Validation
- **On real Windows:** screen-size, mouse-position, `SetCursorPos`, `mouse_event` click, and `SendKeys` all work. (`CopyFromScreen` needs an interactive desktop session — it errors in a headless SSH session, works on a logged-in desktop.)
- **Unit tests** (`test/win.test.ts`, `node:test`): SendKeys escaping + key mapping, 5/5 pass.
- `tsc --noEmit` clean.

### Notes
Originating use case: an air-gapped Windows X-ray inspection client (Windows-on-ARM) that needs Claude/Pi to drive its GUI via this MCP. Follow-ups possible: `getAppState`/`setValue`/Chrome tools for Windows (they still `throw` on win32, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #528
